### PR TITLE
feat: resolve foregroundPgid from the ConPTY console list (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Something already broken? `npx dsh-win32 doctor` names each known trap. `npx dsh
 
 ## Honest limitations (v0.5)
 
-- Interrupting a running command works through Ctrl-C injection (SIGINT/SIGTSTP as PTY input, the ConPTY convention). SIGTERM/SIGKILL against a foreground process stay unsupported on Windows and error honestly. Since v0.5 a failed terminal teardown falls back to `taskkill /T /F` (directly spawned console apps can survive a ConPTY kill).
+- Interrupting a running command works through Ctrl-C injection (SIGINT/SIGTSTP as PTY input, the ConPTY convention). SIGTERM/SIGKILL against a foreground process resolve the command through the ConPTY console list and tree-kill it. What has no win32 answer is stdin-wait probing, which stays `false`, so the harness settles a finished command on the prompt marker rather than on an exact stdin probe. Since v0.5 a failed terminal teardown falls back to `taskkill /T /F` (directly spawned console apps can survive a ConPTY kill).
 - MSYS bash still dies under the `workspace-write` ACL restricted token (measured signature `cygheap_user::init: NtSetInformationToken (TokenDefaultDacl), 0xC0000022`), so the Git Bash preset needs `danger-full-access`. The busybox variant (`minimal-windows-sandboxed`) is the sandbox-safe answer. The trade-off is ash instead of bash (no arrays, no `[[ ]]`).
 - PTY output of legacy-codepage native tools cannot be re-decoded at the plugin layer. node-pty decodes as UTF-8 before any DSH code runs and refuses an encoding override on Windows. Git Bash and busybox default to UTF-8, so the shipped presets are unaffected.
 - Developed against DSH `0.1.0-rc.6`. DSH is a developer preview with breaking changes announced. version pinned, fast-patch policy on every rc bump.

--- a/README.zh.md
+++ b/README.zh.md
@@ -49,7 +49,7 @@ npx dsh-win32 setup --shortcut   # 同上，外加桌面快捷方式
 
 ## 诚实的限制（v0.5）
 
-- 长命令中断已通过 Ctrl-C 注入实现（SIGINT/SIGTSTP 作为 PTY 输入，ConPTY 惯例）。对前台进程的 SIGTERM/SIGKILL 在 Windows 上仍不支持，并如实报错。v0.5 起终端清理失败会回退到 `taskkill /T /F`（直接拉起的控制台程序可能扛过 ConPTY kill）。
+- 长命令中断已通过 Ctrl-C 注入实现（SIGINT/SIGTSTP 作为 PTY 输入，ConPTY 惯例）。对前台进程的 SIGTERM/SIGKILL 现在会通过 ConPTY console 列表解析出该命令并整树终止。真正没有 win32 对应物的是 stdin 等待探测，它恒为 `false`，因此命令完成仍靠提示符标记判定，而非精确的 stdin 探测。v0.5 起终端清理失败会回退到 `taskkill /T /F`（直接拉起的控制台程序可能扛过 ConPTY kill）。
 - MSYS bash 在 `workspace-write` 受限令牌下仍然启动即死（实测签名 `TokenDefaultDacl, 0xC0000022`），所以 Git Bash 预设需要 `danger-full-access`。busybox 变体（`minimal-windows-sandboxed`）是沙箱内的答案；代价是 ash 而非 bash（没有数组、没有 `[[ ]]`）。
 - 旧代码页原生工具的 PTY 输出无法在插件层重新解码：node-pty 在任何 DSH 代码运行之前就按 UTF-8 解码，且在 Windows 上拒绝编码覆盖。Git Bash 和 busybox 默认 UTF-8，随附预设不受影响。
 - 基于 DSH `0.1.0-rc.6` 开发。DSH 是开发者预览版，官方已声明会有破坏性变更。版本锁定，每次 rc 更新快速跟进。

--- a/scripts/foreground-smoke.mjs
+++ b/scripts/foreground-smoke.mjs
@@ -1,0 +1,88 @@
+/**
+ * End-to-end proof for foregroundPgid (#7): the harness can tell "the shell is
+ * back at its prompt" from "a command is running", on the real OS.
+ *
+ * This is the discriminator terminal-bash's readiness check lost while
+ * foregroundPgid returned undefined, where `foreground?.processGroupId ===
+ * this.shellPgid` compared undefined to undefined and passed silently.
+ *
+ * Also prints the parent-walk comparison, which is why the console list is the
+ * mapping and a ppid walk is not: MSYS fork emulation leaves a running
+ * foreground command with no live parent chain to the shell.
+ *
+ * Run after `npm run build`: node scripts/foreground-smoke.mjs
+ */
+
+import { execFileSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import process from 'node:process'
+import { Context } from '@deepseek-ai/cordis'
+import WindowsSubprocessRuntime from '../lib/index.js'
+
+function findBash() {
+  if (process.env.SMOKE_BASH !== undefined) return process.env.SMOKE_BASH
+  if (process.platform !== 'win32') return '/bin/bash'
+  for (const root of [process.env.ProgramFiles, process.env['ProgramFiles(x86)']]) {
+    if (root === undefined) continue
+    const candidate = join(root, 'Git', 'usr', 'bin', 'bash.exe')
+    if (existsSync(candidate)) return candidate
+  }
+  throw new Error('Git Bash not found; set SMOKE_BASH')
+}
+
+function directChildren(pid) {
+  if (process.platform !== 'win32') return '(win32 only)'
+  try {
+    const out = execFileSync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command',
+      `Get-CimInstance Win32_Process -Filter "ParentProcessId=${pid}" | ForEach-Object { $_.ProcessId }`],
+    { encoding: 'utf8', windowsHide: true })
+    return out.trim() === '' ? '(none)' : out.trim().split(/\r?\n/).join(', ')
+  } catch {
+    return '(query failed)'
+  }
+}
+
+const delay = ms => new Promise(resolve => setTimeout(resolve, ms))
+const ctx = new Context()
+await ctx.plugin(WindowsSubprocessRuntime)
+
+const handle = await ctx.subprocess.spawnTerminal({
+  argv: [findBash(), '--noprofile', '--norc', '-i'],
+  cwd: process.cwd(),
+  rows: 24,
+  cols: 80,
+  graceMs: 3000,
+})
+console.log(`pty spawned on ${process.platform}: shell pid ${handle.pid}`)
+await delay(1500)
+
+const idle = await handle.inspectForeground()
+const idleIsShell = idle !== undefined && idle.processGroupId === handle.pid
+
+await handle.write('sleep 30\n')
+await delay(1500)
+const busy = await handle.inspectForeground()
+const busyIsCommand = busy !== undefined && busy.processGroupId !== handle.pid
+
+console.log(`  idle foreground        : ${idle?.processGroupId} (shell is ${handle.pid})`)
+console.log(`  foreground while busy  : ${busy?.processGroupId}`)
+console.log(`  shell's direct children: ${directChildren(handle.pid)}  <- the parent walk`)
+
+await handle.signalForeground('SIGINT')
+await delay(1500)
+const after = await handle.inspectForeground()
+const backToShell = after !== undefined && after.processGroupId === handle.pid
+
+await handle.terminate()
+await ctx.fiber.dispose()
+
+if (!idleIsShell || !busyIsCommand || !backToShell) {
+  console.error(`FAIL: idleIsShell=${idleIsShell} busyIsCommand=${busyIsCommand} backToShell=${backToShell}`)
+  process.exit(1)
+}
+console.log('ok: idle resolves to the shell itself')
+console.log('ok: a running command resolves to the command, not the shell')
+console.log('ok: the shell is foreground again after the interrupt')
+// ConPTY handles keep the event loop alive after dispose on win32; exit explicitly.
+process.exit(0)

--- a/src/console-list.test.ts
+++ b/src/console-list.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { parseConsoleProcessList } from './console-list.ts'
+
+describe('parseConsoleProcessList', () => {
+  it('reads the helper payload', () => {
+    expect(parseConsoleProcessList('{"pids":[57944,66288,43168],"self":57944}'))
+      .toEqual({ pids: [57944, 66288, 43168], self: 57944 })
+  })
+
+  it('drops entries that are not usable pids', () => {
+    const parsed = parseConsoleProcessList('{"pids":[1,null,"2",1.5,1e300,3],"self":9}')
+    expect(parsed).toEqual({ pids: [1, 3], self: 9 })
+  })
+
+  it('returns undefined rather than a half-parsed shape', () => {
+    for (const raw of ['', 'not json', 'null', '[]', '{"pids":[1]}', '{"self":1}', '{"pids":"1,2","self":1}']) {
+      expect(parseConsoleProcessList(raw), raw).toBeUndefined()
+    }
+  })
+
+  it('accepts an empty list, which is a real console state', () => {
+    expect(parseConsoleProcessList('{"pids":[],"self":9}')).toEqual({ pids: [], self: 9 })
+  })
+})

--- a/src/console-list.ts
+++ b/src/console-list.ts
@@ -1,0 +1,117 @@
+/**
+ * ConPTY console process list, the win32 stand-in for a foreground process group.
+ *
+ * Parent links cannot answer "what is running in this terminal" on Windows.
+ * MSYS and Cygwin emulate fork() by spawning an intermediate process that execs
+ * and exits, which severs the chain. A Git Bash PTY running `sleep 20` reports
+ * no direct children at all, while the console list still shows the sleep:
+ *
+ *   console list for shell 43168  ->  {"pids":[57944,66288,43168],"self":57944}
+ *   Win32_Process ParentProcessId=43168  ->  (nothing)
+ *
+ * Console attachment is a property of the console rather than of the process
+ * tree, so it survives the fork emulation.
+ *
+ * GetConsoleProcessList has to run in a separate process, because a process can
+ * be attached to only one console at a time and the host is attached to its own.
+ * node-pty already ships the binding, so a one-shot helper script is enough.
+ * Measured at ~81ms including the child spawn, against ~904ms for a full CIM
+ * enumeration.
+ */
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, writeFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+/** A console's process list, plus the pid of the helper that read it. */
+export interface ConsoleProcessList {
+  pids: number[]
+  /** The helper attaches to the console to query it, so it appears in `pids`. */
+  self: number
+}
+
+/** Undefined until first resolved; `{ path: undefined }` records a known miss. */
+let helperState: { path: string | undefined } | undefined
+
+function nodePtyUtils(): string | undefined {
+  const here = createRequire(import.meta.url)
+  const bases = [here]
+  try {
+    // node-pty is subprocess-local's own dependency, so resolving through it
+    // also covers profiles where this package does not depend on node-pty.
+    bases.push(createRequire(here.resolve('@deepseek-ai/dsh-subprocess-local/package.json')))
+  } catch {
+    // Not installed beside us. The direct base may still resolve.
+  }
+  for (const base of bases) {
+    try {
+      const utils = join(dirname(base.resolve('node-pty/package.json')), 'lib', 'utils.js')
+      if (existsSync(utils)) return utils
+    } catch {
+      continue
+    }
+  }
+  return undefined
+}
+
+function helperScript(): string | undefined {
+  if (helperState !== undefined) return helperState.path
+  const utils = nodePtyUtils()
+  if (utils === undefined) {
+    helperState = { path: undefined }
+    return undefined
+  }
+  try {
+    const path = join(tmpdir(), 'dsh-win32-console-list.cjs')
+    writeFileSync(path, [
+      `const { loadNativeModule } = require(${JSON.stringify(utils)})`,
+      `const list = loadNativeModule('conpty_console_list').module.getConsoleProcessList`,
+      `const pids = list(parseInt(process.argv[2], 10))`,
+      // The helper reports its own pid so the caller can drop it. It is in the
+      // list only because it had to attach to answer the question.
+      `process.stdout.write(JSON.stringify({ pids, self: process.pid }))`,
+    ].join('\n'))
+    helperState = { path }
+    return path
+  } catch {
+    helperState = { path: undefined }
+    return undefined
+  }
+}
+
+/** Parse the helper's stdout. Exported for tests; tolerates any malformed shape. */
+export function parseConsoleProcessList(raw: string): ConsoleProcessList | undefined {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return undefined
+  }
+  if (typeof parsed !== 'object' || parsed === null) return undefined
+  const { pids, self } = parsed as { pids?: unknown, self?: unknown }
+  if (!Array.isArray(pids) || typeof self !== 'number') return undefined
+  return { pids: pids.filter((pid): pid is number => Number.isSafeInteger(pid)), self }
+}
+
+/**
+ * Read the process list of the console `shellPid` owns. Undefined when node-pty
+ * is unreachable, the helper cannot be written, or the console is already gone.
+ * A shell that has exited makes AttachConsole fail, which is an ordinary race
+ * rather than an error, so the caller degrades instead of throwing.
+ */
+export function queryConsoleProcessList(shellPid: number, timeoutMs = 5_000): ConsoleProcessList | undefined {
+  const helper = helperScript()
+  if (helper === undefined) return undefined
+  try {
+    return parseConsoleProcessList(execFileSync(process.execPath, [helper, String(shellPid)], {
+      encoding: 'utf8',
+      windowsHide: true,
+      timeout: timeoutMs,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }))
+  } catch {
+    return undefined
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,8 @@ import { wrapTerminalHandle } from './terminal-wrap.ts'
 
 export { WindowsProcessInspector } from './inspector.ts'
 export type { ProcessIdentity, WindowsInspectorInternals } from './inspector.ts'
+export { parseConsoleProcessList, queryConsoleProcessList } from './console-list.ts'
+export type { ConsoleProcessList } from './console-list.ts'
 export { wrapTerminalHandle } from './terminal-wrap.ts'
 
 export const name = 'subprocess-windows'

--- a/src/inspector.test.ts
+++ b/src/inspector.test.ts
@@ -1,7 +1,16 @@
 import { describe, expect, it } from 'vitest'
 import { WindowsProcessInspector } from './inspector.ts'
+import type { ConsoleProcessList } from './console-list.ts'
 
-function fakeInspector(lines: string[], execLog: string[][] = [], options: { deadPids?: number[], clock?: { t: number } } = {}) {
+interface FakeOptions {
+  deadPids?: number[]
+  clock?: { t: number }
+  /** Omitted means the console query is unavailable, the degraded case. */
+  console?: ConsoleProcessList
+  consoleLog?: number[]
+}
+
+function fakeInspector(lines: string[], execLog: string[][] = [], options: FakeOptions = {}) {
   const clock = options.clock ?? { t: 0 }
   return new WindowsProcessInspector({
     exec(file, args) {
@@ -13,6 +22,10 @@ function fakeInspector(lines: string[], execLog: string[][] = [], options: { dea
       if ((options.deadPids ?? []).includes(pid)) throw new Error('ESRCH')
     },
     now: () => (clock.t += 300),
+    consoleProcessList(shellPid) {
+      options.consoleLog?.push(shellPid)
+      return options.console
+    },
   })
 }
 
@@ -49,11 +62,58 @@ describe('WindowsProcessInspector', () => {
     expect(inspector.isAlive({ pid: 200, started: '999' })).toBe(false)
   })
 
-  it('reports no foreground process group', () => {
+  it('keeps the honest degradations that have no win32 mapping', () => {
     const inspector = fakeInspector(SNAPSHOT)
-    expect(inspector.foregroundPgid(100)).toBeUndefined()
     expect(inspector.isStdinWaiting(100)).toBe(false)
     expect(inspector.processSession(100)).toEqual([])
+  })
+
+  describe('foregroundPgid via the console list (#7)', () => {
+    it('returns the shell itself when only the shell and helper are attached', () => {
+      // What terminal-bash needs to see "the shell is back at its prompt".
+      const inspector = fakeInspector(SNAPSHOT, [], { console: { pids: [100, 9001], self: 9001 } })
+      expect(inspector.foregroundPgid(100)).toBe(100)
+    })
+
+    it('returns the attached command when one is running', () => {
+      const inspector = fakeInspector(SNAPSHOT, [], { console: { pids: [9001, 200, 100], self: 9001 } })
+      expect(inspector.foregroundPgid(100)).toBe(200)
+    })
+
+    it('degrades to undefined when the console cannot be read', () => {
+      // Shell already exited, node-pty missing, helper unwritable. Never guess.
+      expect(fakeInspector(SNAPSHOT).foregroundPgid(100)).toBeUndefined()
+    })
+
+    it('queries the console of the shell it was asked about', () => {
+      const consoleLog: number[] = []
+      fakeInspector(SNAPSHOT, [], { console: { pids: [100], self: 9001 }, consoleLog }).foregroundPgid(100)
+      expect(consoleLog).toEqual([100])
+    })
+
+    it('picks the most recently started stage of a pipeline', () => {
+      // 300 started at 333, 310 at 334; both are attached to the same console.
+      const inspector = fakeInspector(SNAPSHOT, [], { console: { pids: [9001, 300, 310, 100], self: 9001 } })
+      expect(inspector.foregroundPgid(100)).toBe(310)
+    })
+
+    it('compares FILETIME start identities beyond Number precision', () => {
+      // These two collapse to the same double; only BigInt tells them apart.
+      const rows = ['100|1|1', '500|100|133700000000000001', '600|100|133700000000000002']
+      const inspector = fakeInspector(rows, [], { console: { pids: [9001, 500, 600, 100], self: 9001 } })
+      expect(inspector.foregroundPgid(100)).toBe(600)
+    })
+
+    it('falls back to a candidate the snapshot does not know', () => {
+      const inspector = fakeInspector(SNAPSHOT, [], { console: { pids: [9001, 7001, 7002, 100], self: 9001 } })
+      expect([7001, 7002]).toContain(inspector.foregroundPgid(100))
+    })
+
+    it('costs no snapshot exec in the single-candidate case', () => {
+      const log: string[][] = []
+      fakeInspector(SNAPSHOT, log, { console: { pids: [9001, 200, 100], self: 9001 } }).foregroundPgid(100)
+      expect(log).toEqual([])
+    })
   })
 
   it('signals through taskkill, forcing only SIGKILL', () => {

--- a/src/inspector.ts
+++ b/src/inspector.ts
@@ -5,13 +5,15 @@
  * and throws on win32, which is why the persistent shell (and with it the
  * Minimal preset) is dead on Windows. This inspector implements the same
  * contract with Windows facilities: process trees and identity via CIM
- * (Win32_Process), signalling via taskkill. POSIX-only concepts (foreground
- * process groups, sessions, stdin-wait probing) degrade gracefully: the
- * harness then reports no foreground process, which only disables foreground
- * inspection niceties, not the shell itself.
+ * (Win32_Process), signalling via taskkill, foreground resolution via the
+ * ConPTY console process list. Sessions and stdin-wait probing have no win32
+ * equivalent and degrade honestly (empty and false), which costs the harness
+ * only the exact-probe settle path, not the shell itself.
  */
 
 import { execFileSync } from 'node:child_process'
+import { queryConsoleProcessList } from './console-list.ts'
+import type { ConsoleProcessList } from './console-list.ts'
 
 export interface ProcessIdentity {
   pid: number
@@ -24,6 +26,11 @@ export interface WindowsInspectorInternals {
   /** Zero-signal liveness probe; throws when the pid does not exist. */
   kill(pid: number, signal: 0): void
   now(): number
+  /**
+   * Process list of the console `shellPid` owns, plus the pid of the helper
+   * that read it. Undefined when the query is unavailable.
+   */
+  consoleProcessList(shellPid: number): ConsoleProcessList | undefined
 }
 
 const DEFAULT_INTERNALS: WindowsInspectorInternals = {
@@ -34,6 +41,7 @@ const DEFAULT_INTERNALS: WindowsInspectorInternals = {
   }),
   kill: (pid, signal) => { process.kill(pid, signal) },
   now: () => Date.now(),
+  consoleProcessList: shellPid => queryConsoleProcessList(shellPid),
 }
 
 /** One CIM enumeration costs ~900ms on a busy box (#8); terminate polls every
@@ -47,6 +55,15 @@ const LIST_COMMAND = '$ErrorActionPreference="Stop"; Get-CimInstance Win32_Proce
 
 interface ProcessRow extends ProcessIdentity {
   ppid: number
+}
+
+/** FILETIME ticks exceed Number.MAX_SAFE_INTEGER, so compare them as BigInt. */
+function startedAfter(a: string, b: string): boolean {
+  try {
+    return BigInt(a) > BigInt(b)
+  } catch {
+    return a > b
+  }
 }
 
 export class WindowsProcessInspector {
@@ -118,11 +135,48 @@ export class WindowsProcessInspector {
     return this.snapshot().some(row => row.pid === identity.pid && row.started === identity.started)
   }
 
-  /** No foreground process-group concept on Windows; report none. */
-  foregroundPgid(_shellPid: number): number | undefined {
-    return undefined
+  /**
+   * The command currently running in the terminal, or the shell itself when it
+   * is idle. Undefined only when the console cannot be read at all, which keeps
+   * the previous degradation as the fallback rather than inventing a pid.
+   *
+   * Console attachment, not parent links, is the win32 analogue of a foreground
+   * process group; see console-list.ts for the MSYS fork-emulation measurement
+   * that rules the parent walk out. Returning the shell pid when nothing else
+   * is attached is the part terminal-bash actually depends on: it is what
+   * distinguishes "the shell is back at its prompt" from "a child printed the
+   * PROMPT_COMMAND marker it inherited" (#7).
+   */
+  foregroundPgid(shellPid: number): number | undefined {
+    const list = this.internals.consoleProcessList(shellPid)
+    if (list === undefined) return undefined
+    const candidates = list.pids.filter(pid => pid !== shellPid && pid !== list.self)
+    if (candidates.length === 0) return shellPid
+    if (candidates.length === 1) return candidates[0]
+    // A pipeline attaches every stage to the console, so there is no single
+    // correct answer when collapsing a group onto one pid. The most recently
+    // started attachment is the closest stand-in for "what is running now".
+    return this.newestOf(candidates) ?? candidates[0]
   }
 
+  /** Most recently started of `pids`, by start identity. Undefined if none are known. */
+  private newestOf(pids: number[]): number | undefined {
+    const rows = this.snapshot()
+    let newest: ProcessRow | undefined
+    for (const pid of pids) {
+      const row = rows.find(candidate => candidate.pid === pid)
+      if (row === undefined) continue
+      if (newest === undefined || startedAfter(row.started, newest.started)) newest = row
+    }
+    return newest?.pid
+  }
+
+  /**
+   * Windows exposes no reliable "this process is blocked on a console read"
+   * probe. Reporting false keeps terminal-bash's exact-probe settle path
+   * unreachable, which is the safe direction: claiming a wait that is not
+   * happening would settle a still-running command.
+   */
   isStdinWaiting(_pgid: number): boolean {
     return false
   }
@@ -138,7 +192,11 @@ export class WindowsProcessInspector {
     }
   }
 
-  /** Unreachable in practice (foregroundPgid is always undefined); tree-kill defensively. */
+  /**
+   * Reachable since foregroundPgid resolves: this is how SIGTERM/SIGKILL against
+   * a foreground command land. `/T` covers the command's own descendants, which
+   * is the closest Windows has to signalling a process group.
+   */
   signalGroup(pgid: number, signal: { toString(): string }): void {
     const force = String(signal) === 'SIGKILL' ? ['/F'] : []
     try {

--- a/src/terminal-wrap.ts
+++ b/src/terminal-wrap.ts
@@ -10,9 +10,10 @@
  * whatever is running, exactly like a user pressing Ctrl-C. Git Bash (MSYS)
  * forwards ^C as SIGINT to its foreground job.
  *
- * SIGINT and SIGTSTP map to control characters. SIGTERM/SIGKILL/SIGHUP have
- * no keyboard equivalent and keep the stock (throwing) behavior rather than
- * pretending a delivery happened.
+ * SIGINT and SIGTSTP map to control characters. SIGTERM/SIGKILL/SIGHUP have no
+ * keyboard equivalent and stay on the stock path, which since the console-list
+ * inspector resolves a real foreground now tree-kills that command rather than
+ * throwing "cannot resolve foreground process group".
  */
 
 import { spawnSync } from 'node:child_process'


### PR DESCRIPTION
Closes #7.

Built to the shape you asked for: helper and parsing behind `WindowsInspectorInternals`, `foregroundPgid` returning the console-derived candidate, and the MSYS fork-emulation measurement as a code comment.

## Shape

`src/console-list.ts` is new and owns the OS side. It resolves node-pty (from here, falling back to resolving through `@deepseek-ai/dsh-subprocess-local`, which depends on it), writes a one-shot helper to tmp, runs it, and parses the payload. `parseConsoleProcessList` is exported separately so the parsing is testable without spawning anything.

`WindowsInspectorInternals` gains one member:

```ts
consoleProcessList(shellPid: number): ConsoleProcessList | undefined
```

so everything the inspector does with the list stays injectable. What is left in the class is selection logic, unit-tested against fakes: drop the helper pid and the shell pid, return the shell when nothing remains, and collapse a multi-stage pipeline onto its most recently started attachment.

`undefined` is preserved as the fallback for every failure (node-pty unreachable, helper unwritable, console already gone because the shell exited). The degradation you had stays exactly as it was rather than becoming a guess.

## What this does and does not restore

It restores the discriminator, which is the `#7` point: `shellPgid` now gets assigned, and `foreground?.processGroupId === this.shellPgid` compares real pids instead of `undefined === undefined`.

It does **not** enable the `exactProbeAfterMs` settle path. That one runs through `operation.acceptsStdinWait(pgid, waiting)`, which returns `waiting` in every branch, and `isStdinWaiting` still returns `false`. I left it false on purpose and documented why in the code: Windows has no reliable console-read-block probe, and claiming a wait that is not happening would settle a still-running command. So this PR is a strict gain with no new guessing.

One behavior change worth calling out: `signalGroup` was annotated "unreachable in practice" and is now reachable. `SIGTERM`/`SIGKILL` against a foreground command resolve and tree-kill it instead of throwing `cannot resolve foreground process group`. `SIGKILL` against an idle shell still hits upstream's refusal guard at `terminal.ts:98`, which works precisely because v0.6.0 made the pty pid the real shell rather than the wrapper. I updated the two README lines and the `terminal-wrap.ts` header that claimed those signals stay unsupported.

I left `docs/core-adoption.md` alone since you said you would take the doc update on merge. Its contract table will need the `foregroundPgid` row changed.

## Verification

`scripts/foreground-smoke.mjs` is new and proves the three states end to end. It also prints the parent walk next to the console answer, so the reason for the mapping is visible in the output rather than only in a comment:

```
pty spawned on win32: shell pid 65476
  idle foreground        : 65476 (shell is 65476)
  foreground while busy  : 60260
  shell's direct children: (none)  <- the parent walk
ok: idle resolves to the shell itself
ok: a running command resolves to the command, not the shell
ok: the shell is foreground again after the interrupt
```

That `(none)` is with `sleep 30` running in the foreground. It is the whole argument for console attachment over a ppid walk, reproducible on demand.

Existing smokes still pass unchanged on this machine:

```
pty-smoke      ok: persistent state survived / ok: foreground interrupt delivered (130)
encoding-smoke ok: collect reader served "编译完成" on win32
doctor         ok node 24.13.1 / ok Git Bash: C:\Program Files\Git\usr\bin\bash.exe
```

`vitest run` is 41 passing, up from 30. `tsc -p . --noEmit` is clean.

Suggested CI step, mirroring the pty-smoke job:

```yaml
- name: foreground resolution smoke (#7)
  timeout-minutes: 5
  run: node scripts/foreground-smoke.mjs
```

It is win32-only in substance; on POSIX it exercises the stock inspector and should also pass, which makes it a reasonable cross-platform guard.

## Notes

- FILETIME ticks exceed `Number.MAX_SAFE_INTEGER`, so the pipeline tiebreak compares start identities as `BigInt`. There is a unit test with two values that collapse to the same double.
- The single-candidate path takes no CIM snapshot at all, so the common case stays at the ~81ms console query. The snapshot is only consulted to order multiple attachments, and there is a test asserting the exec log stays empty.
- Collapsing a pipeline onto one pid is lossy by nature. `signalGroup` uses `/T`, so the chosen stage's own descendants are covered, but sibling stages are not. Documented in the comment rather than papered over.
