### PR TITLE
fix: wire the bundle on boxes without pnpm, and report it in doctor

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -40,7 +40,7 @@ npx dsh-win32 setup              # bundle + preset + health report
 npx dsh-win32 setup --shortcut   # same, plus the desktop shortcut
 ```
 
-The preset appears in the picker immediately. Requires [Git for Windows](https://git-scm.com) (`winget install Git.Git`).
+The preset appears in the picker immediately. Requires [Git for Windows](https://git-scm.com) (`winget install Git.Git`). Wiring the bundle also needs pnpm, because `dsh plugin add` installs into the profile directory with it. `setup` enables pnpm through corepack when it is missing, and `doctor` reports it either way.
 
 Something already broken? `npx dsh-win32 doctor` names each known trap. `npx dsh-win32 fix` repairs what it safely can (pins the broken koffi prebuilt).
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npx dsh-win32 setup --sandboxed  # 额外装沙箱内可用的 busybox 变体
 npx dsh-win32 setup --shortcut   # 额外建桌面快捷方式
 ```
 
-预设立即出现在选择器里，无需重启。需要 [Git for Windows](https://git-scm.com)（`winget install Git.Git`）。
+预设立即出现在选择器里，无需重启。需要 [Git for Windows](https://git-scm.com)（`winget install Git.Git`）。接入 bundle 还需要 pnpm，因为 `dsh plugin add` 是用它装进 profile 目录的。缺失时 `setup` 会通过 corepack 自动启用，`doctor` 也会单独列出该项。
 
 已经出问题了？`npx dsh-win32 doctor` 逐项指出已知的坑（koffi 3.1.3/3.1.4 损坏预编译导致的安装失败与选择器崩溃、缺 PowerShell 7 时 5.1 在沙箱里的 0xC0000142、localhost 与 127.0.0.1 的 403、System32 里的 WSL 假 bash），`npx dsh-win32 fix` 自动修复能安全修的部分。
 

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -62,6 +62,32 @@ function findPwsh7() {
   return first !== undefined && first !== '' ? first : undefined
 }
 
+/**
+ * pnpm backs the profile-directory install: `dsh plugin add` forwards to it,
+ * so a box without pnpm fails the bundle wiring with a bare
+ * "'pnpm' is not recognized" and no hint about what is actually missing (#13).
+ */
+function findPnpm() {
+  const located = tryExec(WIN ? 'where.exe' : 'which', ['pnpm'])
+  const first = (located ?? '').split(/\r?\n/)[0]?.trim()
+  return first !== undefined && first !== '' ? first : undefined
+}
+
+/** node ships corepack, so a missing pnpm is recoverable without a download. */
+function enablePnpmViaCorepack() {
+  try {
+    // Constant argv; shell:true only because Windows corepack is a .cmd shim (CVE-2024-27980 policy).
+    execFileSync(WIN ? 'corepack.cmd' : 'corepack', ['enable', 'pnpm'], {
+      stdio: 'ignore',
+      windowsHide: true,
+      shell: WIN,
+    })
+  } catch {
+    return undefined
+  }
+  return findPnpm()
+}
+
 /** koffi 3.1.3/3.1.4 ship a broken win32-x64 prebuilt (segfault chain: install failures, picker crash, silent session-save crash). */
 function scanKoffi() {
   const results = []
@@ -110,6 +136,10 @@ function collectChecks() {
   // a threshold derived from an observed failure (#1719, #2259).
   if (major > 22 || (major === 22 && minor >= 19)) add('node', 'pass', process.versions.node)
   else add('node', 'fail', `node ${process.versions.node}. DSH needs ^22.19.0 || >=24.0.0 (deepseek-harness root package.json)`)
+
+  const pnpm = findPnpm()
+  if (pnpm !== undefined) add('pnpm', 'pass', pnpm)
+  else add('pnpm', 'warn', 'pnpm not found. The bundle installs into the profile dir with pnpm, so wiring fails without it. setup enables it through corepack, or: npm install -g pnpm')
 
   const gitBash = WIN ? findGitBash() : undefined
   if (!WIN) {
@@ -204,6 +234,15 @@ function ensureBundle() {
   if (bundleInstalled()) {
     ok('bundle dsh-win32 already wired into the web profile')
     return
+  }
+  if (findPnpm() === undefined) {
+    console.log('pnpm not found, enabling it through corepack (ships with node)...')
+    if (enablePnpmViaCorepack() === undefined) {
+      warn('pnpm is missing and corepack could not enable it, so the wiring below will fail')
+      info('install pnpm and re-run: npm install -g pnpm')
+    } else {
+      ok('pnpm enabled through corepack')
+    }
   }
   console.log('wiring the dsh-win32 bundle into the web profile (one-time)...')
   // -w: the profile dir is a pnpm workspace root; pnpm 10+ refuses a bare add there.

--- a/src/doctor-envelope.test.ts
+++ b/src/doctor-envelope.test.ts
@@ -98,4 +98,15 @@ describe('dsh-doctor/v1 envelope', () => {
       expect(byName[name]).toBe('skip')
     }
   })
+
+  // #13: a clean box has node and Git but no pnpm, and the bundle wiring dies
+  // on it with a bare "'pnpm' is not recognized". The check is platform-
+  // agnostic, so it must report a real status everywhere rather than joining
+  // the win32 skip list whose count the CI envelope gate asserts on.
+  it('reports pnpm on every platform, never as a skip', () => {
+    const { envelope } = runDoctor()
+    const pnpm = envelope.checks.find((c: any) => c.name === 'pnpm')
+    expect(pnpm).toBeDefined()
+    expect(['pass', 'warn']).toContain(pnpm.status)
+  })
 })


### PR DESCRIPTION
Closes #13.

## The problem

`ensureBundle()` forwards to `dsh plugin add`, which installs into the profile
directory **with pnpm**. The README asks for node, Git and PowerShell 7 and
nothing else, so a clean Windows box has no pnpm and the wiring dies with:

```
dsh: initialized profile web at C:\Users\...\.dsh\profiles\web
'pnpm' is not recognized as an internal or external command, operable program or batch file.
dsh: pnpm failed in profile directory C:\Users\...\.dsh\profiles\web
  WARN  bundle wiring failed — the preset still installs below; wire the bundle manually with:
  tip   npx --yes @deepseek-ai/dsh plugin --profile web add -w dsh-win32
```

The presets and the shortcut still install and `doctor` stays green, so the run
reads as a success while the bundle is absent from the profile. Nothing in the
output names pnpm as the prerequisite that is missing.

## The change

- **`setup` self-heals.** When pnpm is not on PATH, `ensureBundle()` runs
  `corepack enable pnpm` first. corepack ships with node, so this needs no
  download and no admin-only install. If corepack cannot do it either, the run
  says so and names the fix instead of failing anonymously.
- **`doctor` reports it.** New platform-agnostic `pnpm` check: `pass` with the
  resolved path, `warn` with the corepack/`npm i -g pnpm` remedy when missing.
  The gap now shows up in the health report rather than only mid-run.
- **Both READMEs** mention pnpm alongside the Git for Windows prerequisite.

The check sits with `node`, ahead of the win32 early return, on purpose — it is
not a Windows-only concern, and keeping it out of the skip list preserves the
skip counts the CI envelope gate asserts (`0` on win32, `4` elsewhere).

## Verification

`npm run build` and `npm test` pass — 50 tests, including one new envelope test
asserting `pnpm` is present and never a `skip`.

Both branches exercised on Windows 11 with dsh-win32 at this commit:

```
# pnpm on PATH
  ok    pnpm: C:\Users\...\AppData\Roaming\npm\pnpm

# PATH without the npm global bin
  WARN  pnpm: pnpm not found. The bundle installs into the profile dir with pnpm,
        so wiring fails without it. setup enables it through corepack, or: npm install -g pnpm
```

The CI envelope gate from `ci.yml` run locally against `doctor --json`:

```
envelope ok, exit 0 {"pass":6,"warn":0,"fail":0,"skip":0}
names: node, pnpm, git_bash, powershell, koffi, sandbox_shell
```

## Found how

Clean Windows 11 box, following the README from scratch: `winget` node + Git +
PowerShell 7, then `npx dsh-win32 setup --sandboxed --shortcut`. The wiring
failed on the first run. `npm install -g pnpm` plus the tip command in the
warning recovered it, which is what this PR automates.
