### PR TITLE
fix: anchor the eval rewrite on the ANSI-C quoting the core emits

### DIFF
--- a/scripts/sandbox-smoke.mjs
+++ b/scripts/sandbox-smoke.mjs
@@ -108,8 +108,17 @@ try {
     // Seeing the marker in the scrollback does not mean the operation settled.
     await firstSend.done.catch(() => {})
     const wrapMarker = `wrapped-${process.pid}`
-    const wrapped = `printf '%s\\n' 'S-${wrapMarker}'; eval -- 'echo ${wrapMarker}:$((6*7))'`
-      + `; __dsh_persistent_bash_status=$?; printf '%s%s\\n' 'E-${wrapMarker}:' "$__dsh_persistent_bash_status"`
+    // quoteForBash in dsh-tool-bash-persistent emits ANSI-C quoting, so the real
+    // wrapper reads `eval -- $'...'` and not `eval -- '...'`. Hand-writing the
+    // plain-quote shape here is what let 0.8.1 ship with the rewrite disabled
+    // while this gate stayed green, so the fixture has to match what the core
+    // actually sends.
+    const quoteForBash = value =>
+      `$'${value.replaceAll('\\', '\\\\').replaceAll("'", "\\'")}'`
+    const wrapped = `printf '%s\\n' ${quoteForBash(`S-${wrapMarker}`)}`
+      + `; eval -- ${quoteForBash(`echo ${wrapMarker}:$((6*7))`)}`
+      + `; __dsh_persistent_bash_status=$?`
+      + `; printf '%s%s\\n' ${quoteForBash(`E-${wrapMarker}:`)} "$__dsh_persistent_bash_status"`
     ctx.terminals.startSend(agent, spawned.sessionId, { text: wrapped, submit: true })
     const wantOutput = `${wrapMarker}:42`
     const wantStatus = `E-${wrapMarker}:0`

--- a/src/terminal-wrap.test.ts
+++ b/src/terminal-wrap.test.ts
@@ -72,27 +72,53 @@ describe('wrapTerminalHandle', () => {
 })
 
 describe('toPortableEval', () => {
+  // Replicated from dsh-tool-bash-persistent so the fixture is the string that
+  // actually reaches the PTY. 0.8.1 anchored on a hand-written plain-quote
+  // wrapper, which matched nothing in production and shipped the rewrite
+  // disabled while this suite stayed green.
+  const quoteForBash = (value: string) =>
+    `$'${value
+      .replaceAll('\\', '\\\\')
+      .replaceAll("'", "\\'")
+      .replaceAll('\r', '\\r')
+      .replaceAll('\n', '\\n')}'`
   const wrap = (command: string) =>
-    `printf '%s\\n' 'S1'; eval -- '${command}'; __dsh_persistent_bash_status=$?; printf '%s%s\\n' 'E1' "$__dsh_persistent_bash_status"`
+    `printf '%s\\n' ${quoteForBash('S1')}; eval -- ${quoteForBash(command)};`
+    + ` __dsh_persistent_bash_status=$?; printf '%s%s\\n' ${quoteForBash('E1')}`
+    + ` "$__dsh_persistent_bash_status"`
 
   it('replaces the bashism with the portable leading-space form', () => {
     expect(toPortableEval(wrap('echo ok'))).toBe(
-      `printf '%s\\n' 'S1'; eval ' echo ok'; __dsh_persistent_bash_status=$?; printf '%s%s\\n' 'E1' "$__dsh_persistent_bash_status"`,
+      `printf '%s\\n' $'S1'; eval $' echo ok';`
+      + ` __dsh_persistent_bash_status=$?; printf '%s%s\\n' $'E1'`
+      + ` "$__dsh_persistent_bash_status"`,
     )
   })
 
+  it('anchors on the ANSI-C quoting the core emits, not on plain quotes', () => {
+    // The regression that shipped in 0.8.1. The wrapper carries a `$` between
+    // the separator and the quote, so a plain-quote anchor never fires and the
+    // sandboxed preset keeps dying with `eval: --: not found`.
+    const wrapped = wrap('MARK=box7')
+    expect(wrapped).toContain("; eval -- $'")
+    expect(toPortableEval(wrapped)).not.toBe(wrapped)
+    expect(toPortableEval(wrapped)).not.toContain('eval -- ')
+  })
+
   it('rewrites only the wrapper, never a match inside the command', () => {
-    // A command that itself contains the wrapper text, quoted the way
-    // quoteForBash would escape it.
-    const rewritten = toPortableEval(wrap(`echo '\\''; eval -- '\\''x`))
-    expect(rewritten.indexOf("eval ' ")).toBe(rewritten.indexOf('eval'))
-    expect(rewritten.match(/eval ' /g)).toHaveLength(1)
-    expect(rewritten).toContain("; eval -- '")
+    // quoteForBash escapes every quote, so the command's own copy of the
+    // wrapper text arrives escaped and cannot be mistaken for the real one.
+    const rewritten = toPortableEval(wrap(`echo "; eval -- $'x"`))
+    expect(rewritten.match(/; eval \$' /g)).toHaveLength(1)
   })
 
   it('leaves anything that is not the wrapper alone', () => {
-    for (const data of ['\x03', 'echo hello\n', "eval -- 'bare'", `printf '%s\\n' 'S1'; eval -- 'no tail'`]) {
-      expect(toPortableEval(data)).toBe(data)
-    }
+    const notWrappers = [
+      '\x03',
+      'echo hello\n',
+      "eval -- $'bare'",
+      `printf '%s\\n' $'S1'; eval -- $'no tail'`,
+    ]
+    for (const data of notWrappers) expect(toPortableEval(data)).toBe(data)
   })
 })

--- a/src/terminal-wrap.ts
+++ b/src/terminal-wrap.ts
@@ -37,7 +37,7 @@ function taskkillTree(pid: number): void {
 /**
  * `dsh-tool-bash-persistent` wraps every command as
  *
- *   printf '%s\n' 'START'; eval -- 'CMD'; __dsh_persistent_bash_status=$?; ...
+ *   printf '%s\n' $'START'; eval -- $'CMD'; __dsh_persistent_bash_status=$?; ...
  *
  * and `eval --` is a bashism. POSIX shells do not accept `--` for the `eval`
  * special builtin, so busybox ash reads `--` as the command name and every
@@ -52,10 +52,16 @@ function taskkillTree(pid: number): void {
  * both shells, `eval ' -n hi'` behaves exactly like bash's `eval -- '-n hi'`,
  * so this is safe to apply on the Git Bash preset too.
  *
+ * The command is quoted with ANSI-C syntax, so the wrapper reads `eval -- $'…'`
+ * and not `eval -- '…'`. Anchoring on the plain-quote form matched nothing in
+ * production and shipped 0.8.1 with the rewrite disabled, so the `$` is load
+ * bearing. The test fixture is built from the core's own quoting for the same
+ * reason, since a hand-written wrapper can drift from what actually ships.
+ *
  * Reported upstream at deepseek-harness#2271. This rewrite goes away when the
  * fix lands there.
  */
-const WRAPPED_EVAL = "; eval -- '"
+const WRAPPED_EVAL = "; eval -- $'"
 
 export function toPortableEval(data: string): string {
   // Anchored on both ends of the known wrapper. A command that merely contains
@@ -63,7 +69,7 @@ export function toPortableEval(data: string): string {
   if (!data.startsWith("printf '%s\\n' ") || !data.includes(WRAPPED_EVAL)) return data
   if (!data.trimEnd().endsWith('"$__dsh_persistent_bash_status"')) return data
   const at = data.indexOf(WRAPPED_EVAL)
-  return `${data.slice(0, at)}; eval ' ${data.slice(at + WRAPPED_EVAL.length)}`
+  return `${data.slice(0, at)}; eval $' ${data.slice(at + WRAPPED_EVAL.length)}`
 }
 
 /**


### PR DESCRIPTION
## What is broken

0.8.1 ships `toPortableEval` disabled. It looks for a plain single quote after the
separator.

```js
const WRAPPED_EVAL = "; eval -- '"
```

`dsh-tool-bash-persistent` wraps the command with `quoteForBash`, which emits ANSI-C
quoting, so the wrapper that actually reaches the PTY reads

```
printf '%s\n' $'START'; eval -- $'MARK=box7'; __dsh_persistent_bash_status=$?; ...
```

The `$` sits between the separator and the quote, `data.includes(WRAPPED_EVAL)` is false,
and the function returns its input untouched. Every command in the sandboxed preset still
dies with `eval: --: not found` at exit 127, while `doctor` reports all green.

Importing the published module and feeding it the real wrapper output confirms it.

```
CHANGED?          false
still has eval -- true
pattern searched  "; eval -- '"
text present      "; eval -- $'MARK"
```

## Why nothing caught it

Two fixtures hand-wrote the wrapper with plain quotes, and both agreed with the buggy
constant rather than with the core.

The unit test.

```ts
const wrap = (command: string) =>
  `printf '%s\n' 'S1'; eval -- '${command}'; ...`
```

The busybox gate in `scripts/sandbox-smoke.mjs`.

```js
const wrapped = `printf '%s\n' 'S-${wrapMarker}'; eval -- 'echo ${wrapMarker}:$((6*7))'`
```

Plain quotes everywhere in the tests, ANSI-C quoting in production. The suite and the gate
exercised a string shape that never occurs, so both stayed green while the shipped rewrite
matched nothing.

This PR made that visible. The first commit fixed only the constant, and CI immediately
failed the `busybox-sandboxed` gate with the exact signature the plugin exists to prevent.

```
dsh> printf '%s\n' 'S-wrapped-1820'; eval -- 'echo wrapped-1820:$((6*7))'; ...
     sh: eval: --: not found
     E-wrapped-1820:127
```

That is the gate proving it had been validating the wrong string all along.

## The change

Two commits.

1. `WRAPPED_EVAL` and the replacement both carry the `$`, and the unit fixture is built from
   a replica of the core's `quoteForBash`. A new test names the regression directly.
2. The smoke wraps its marker the same way, so the gate now fails whenever the rewrite stops
   matching production instead of agreeing with a stale constant.

Reverting only `src/terminal-wrap.ts` and keeping the new tests makes three of them fail,
including `anchors on the ANSI-C quoting the core emits, not on plain quotes`.

## Verification

54 tests pass, up from 50, with `terminal-wrap` going from 6 to 10. Full CI green including
the `busybox-sandboxed` gate.

End to end on Windows 11 with this build packed and installed into the web profile. New
session, preset `Minimal (Windows, sandboxed)`, access mode `Workspace Write`, two separate
turns.

| turn | tool call | result |
|---|---|---|
| 1 | `bash {"command": "MARK=box7"}` | no output, exit 0 |
| 2 | `bash {"command": "echo sandbox:$MARK:$(pwd)"}` | `sandbox:box7:C:/work/demo` |

Before this change both turns returned `eval: --: not found` at exit 127.

The same run also cleared the rest of the Windows checklist. The sandbox denied a write to
`C:/Windows/Temp` with `Permission denied` at exit 1 and left nothing on disk, a GBK file
read back intact through `str_replace_editor`, and a `sleep 60` interrupted from the UI left
the session alive with shell state carrying into the next two tool calls.

## Adjacent findings, filed separately

The upgrade path and the interrupt error text are tracked in their own issues rather than
widening this change.
