### PR TITLE
fix: resolve foreground beside a background job (#11)

### DIFF
--- a/scripts/foreground-smoke.mjs
+++ b/scripts/foreground-smoke.mjs
@@ -74,15 +74,33 @@ await delay(1500)
 const after = await handle.inspectForeground()
 const backToShell = after !== undefined && after.processGroupId === handle.pid
 
+// A backgrounded job stays attached to the console for its whole life, so an
+// idle shell still has a candidate. Resolution has to survive that or every
+// later command in the session settles on the silence timeout instead of the
+// prompt (#11). Poll while the foreground command runs, because the answer is
+// derived from watching it appear and go, not from one reading.
+await handle.write('sleep 300 &\n')
+await delay(1500)
+await handle.write('sleep 3\n')
+for (let i = 0; i < 12; i += 1) {
+  await handle.inspectForeground()
+  await delay(250)
+}
+const withJob = await handle.inspectForeground()
+const idleDespiteJob = withJob !== undefined && withJob.processGroupId === handle.pid
+console.log(`  foreground with a background job: ${withJob?.processGroupId} (shell is ${handle.pid})`)
+
 await handle.terminate()
 await ctx.fiber.dispose()
 
-if (!idleIsShell || !busyIsCommand || !backToShell) {
-  console.error(`FAIL: idleIsShell=${idleIsShell} busyIsCommand=${busyIsCommand} backToShell=${backToShell}`)
+if (!idleIsShell || !busyIsCommand || !backToShell || !idleDespiteJob) {
+  console.error(`FAIL: idleIsShell=${idleIsShell} busyIsCommand=${busyIsCommand}`
+    + ` backToShell=${backToShell} idleDespiteJob=${idleDespiteJob}`)
   process.exit(1)
 }
 console.log('ok: idle resolves to the shell itself')
 console.log('ok: a running command resolves to the command, not the shell')
 console.log('ok: the shell is foreground again after the interrupt')
+console.log('ok: an idle shell still resolves to itself beside a background job')
 // ConPTY handles keep the event loop alive after dispose on win32; exit explicitly.
 process.exit(0)

--- a/src/inspector.test.ts
+++ b/src/inspector.test.ts
@@ -116,6 +116,96 @@ describe('WindowsProcessInspector', () => {
     })
   })
 
+  describe('background jobs stay attached, so foreground is resolved over time (#11)', () => {
+    /** Drive the inspector through a scripted sequence of console readings. */
+    function sequence(readings: number[][]) {
+      let index = 0
+      const inspector = new WindowsProcessInspector({
+        exec: () => SNAPSHOT.join('\r\n'),
+        kill: () => {},
+        now: () => 0,
+        consoleProcessList: () => ({ pids: [...readings[Math.min(index, readings.length - 1)]!, 100], self: 9001 }),
+      })
+      return () => {
+        const value = inspector.foregroundPgid(100)
+        index += 1
+        return value
+      }
+    }
+
+    it('reports the shell once a foreground command has come and gone beside a background job', () => {
+      // 200 is backgrounded first, then 300 runs in the foreground and exits.
+      const next = sequence([
+        [],           // idle
+        [200],        // `sleep &` job appears; indistinguishable at this instant
+        [200, 300],   // a foreground command starts
+        [200, 300],   // still running
+        [200],        // it exits, and 200 is exposed as the background job
+        [200],        // stays exposed
+      ])
+      expect(next()).toBe(100)
+      expect(next()).toBe(200)
+      expect(next()).toBe(300)
+      expect(next()).toBe(300)
+      expect(next()).toBe(100)
+      expect(next()).toBe(100)
+    })
+
+    it('does not let a stale console entry hand the foreground back to a background job', () => {
+      // The console list outlives exit, and the CIM snapshot does not know 310,
+      // so an unguarded newest-of pick would fall back to 200 mid-command.
+      const next = sequence([
+        [],
+        [200],
+        [200, 310],
+        [200, 310],
+        [200, 310],
+      ])
+      next()
+      next()
+      expect(next()).toBe(310)
+      expect(next()).toBe(310)
+      expect(next()).toBe(310)
+    })
+
+    it('keeps resolving later foreground commands once a job is known to be resting', () => {
+      const next = sequence([
+        [], [200], [200, 300], [200], [200, 310], [200], [200],
+      ])
+      next(); next(); next()
+      expect(next()).toBe(100)
+      expect(next()).toBe(310)
+      expect(next()).toBe(100)
+      expect(next()).toBe(100)
+    })
+
+    it('drops a resting job from memory when it exits', () => {
+      const next = sequence([
+        [], [200], [200, 300], [200], [], [300],
+      ])
+      next(); next(); next(); next()
+      expect(next()).toBe(100)
+      // 300 reappearing is a new command, not the resting entry it once was.
+      expect(next()).toBe(300)
+    })
+
+    it('forgets per-terminal state when the console can no longer be read', () => {
+      let list: ConsoleProcessList | undefined = { pids: [100, 200, 9001], self: 9001 }
+      const inspector = new WindowsProcessInspector({
+        exec: () => SNAPSHOT.join('\r\n'),
+        kill: () => {},
+        now: () => 0,
+        consoleProcessList: () => list,
+      })
+      inspector.foregroundPgid(100)
+      list = undefined
+      expect(inspector.foregroundPgid(100)).toBeUndefined()
+      list = { pids: [100, 200, 9001], self: 9001 }
+      // State was dropped with the terminal, so 200 is a fresh command again.
+      expect(inspector.foregroundPgid(100)).toBe(200)
+    })
+  })
+
   it('signals through taskkill, forcing only SIGKILL', () => {
     const log: string[][] = []
     const inspector = fakeInspector([], log)

--- a/src/inspector.ts
+++ b/src/inspector.ts
@@ -57,6 +57,25 @@ interface ProcessRow extends ProcessIdentity {
   ppid: number
 }
 
+/**
+ * Per-terminal memory for foreground resolution.
+ *
+ * The console list answers "attached to this console", not "owns the
+ * foreground", and Windows has no query for the latter. A backgrounded job stays
+ * attached for its whole life, so a point-in-time read cannot tell it from the
+ * command the user is waiting on. The difference only shows over time: a
+ * foreground command exits before the shell takes the terminal back, a
+ * background job does not.
+ */
+interface TerminalForegroundState {
+  /** Attachments known to be background jobs. */
+  resting: Set<number>
+  /** Attachments seen on the previous call. */
+  previous: Set<number>
+  /** Pid last reported as the foreground, if any. */
+  reported: number | undefined
+}
+
 /** FILETIME ticks exceed Number.MAX_SAFE_INTEGER, so compare them as BigInt. */
 function startedAfter(a: string, b: string): boolean {
   try {
@@ -68,6 +87,7 @@ function startedAfter(a: string, b: string): boolean {
 
 export class WindowsProcessInspector {
   private cached: { at: number, rows: ProcessRow[] } | undefined
+  private readonly terminals = new Map<number, TerminalForegroundState>()
 
   constructor(private readonly internals: WindowsInspectorInternals = DEFAULT_INTERNALS) {}
 
@@ -149,14 +169,73 @@ export class WindowsProcessInspector {
    */
   foregroundPgid(shellPid: number): number | undefined {
     const list = this.internals.consoleProcessList(shellPid)
-    if (list === undefined) return undefined
+    if (list === undefined) {
+      this.forgetTerminal(shellPid)
+      return undefined
+    }
     const candidates = list.pids.filter(pid => pid !== shellPid && pid !== list.self)
-    if (candidates.length === 0) return shellPid
-    if (candidates.length === 1) return candidates[0]
-    // A pipeline attaches every stage to the console, so there is no single
-    // correct answer when collapsing a group onto one pid. The most recently
-    // started attachment is the closest stand-in for "what is running now".
-    return this.newestOf(candidates) ?? candidates[0]
+    const attached = new Set(candidates)
+    const state = this.terminalState(shellPid)
+    const previous = state.previous
+
+    // A resting pid that has exited stops resting. Presence is enough here: the
+    // entry is dropped on the first poll after the exit, so the window in which
+    // a recycled pid could inherit resting status is one poll interval.
+    for (const pid of state.resting) {
+      if (!attached.has(pid)) state.resting.delete(pid)
+    }
+
+    // Absorption. When the command we last reported as foreground exits, every
+    // attachment that coexisted with it was, by definition, running alongside a
+    // foreground command, so it is a background job. Restricting this to pids
+    // seen in the previous observation keeps a command that started in the same
+    // interval from being absorbed with them.
+    if (state.reported !== undefined && !attached.has(state.reported)) {
+      for (const pid of candidates) {
+        if (previous.has(pid)) state.resting.add(pid)
+      }
+      state.reported = undefined
+    }
+    state.previous = attached
+
+    const fresh = candidates.filter(pid => !state.resting.has(pid))
+    if (fresh.length === 0) {
+      // Only background jobs are attached, so the shell owns the terminal.
+      state.reported = undefined
+      return shellPid
+    }
+    // Nothing new has attached, so the command already reported stays the answer.
+    // The console list outlives process exit by a poll or two while `newestOf`
+    // reads a CIM snapshot that does not, so without this the pick falls back to
+    // an older attachment (a background job) while the real foreground lingers.
+    // That rewrites `reported` and destroys the disappearance absorption needs,
+    // which is how a background job stayed "foreground" for a whole session.
+    // The guard is conditional on nothing having appeared, or the first job put
+    // in the background would be held as the answer forever.
+    const appeared = fresh.some(pid => !previous.has(pid))
+    if (!appeared && state.reported !== undefined && fresh.includes(state.reported)) {
+      return state.reported
+    }
+    // A pipeline attaches every stage, so there is no single correct answer when
+    // collapsing a group onto one pid. The most recently started attachment is
+    // the closest stand-in for "what is running now".
+    const pick = fresh.length === 1 ? fresh[0]! : (this.newestOf(fresh) ?? fresh[0]!)
+    state.reported = pick
+    return pick
+  }
+
+  private terminalState(shellPid: number): TerminalForegroundState {
+    let state = this.terminals.get(shellPid)
+    if (state === undefined) {
+      state = { resting: new Set(), previous: new Set(), reported: undefined }
+      this.terminals.set(shellPid, state)
+    }
+    return state
+  }
+
+  /** Drop per-terminal state once its console can no longer be read. */
+  private forgetTerminal(shellPid: number): void {
+    this.terminals.delete(shellPid)
   }
 
   /** Most recently started of `pids`, by start identity. Undefined if none are known. */


### PR DESCRIPTION
Closes #11, and fixes the regression I disclosed there.

## The regression

A backgrounded job stays attached to the console for its whole life. So with the shell idle, `candidates` is non-empty and `foregroundPgid` returned the job. `terminal-bash` then never matched `shellPgid`, and every later command in the session settled on `inferred_idle` (**3500ms**) instead of the prompt path (**50ms**). Before #9 this case settled on the fast path, because `foregroundPgid` was `undefined` and `undefined === undefined` passed. My change made it worse.

## What I checked before writing code

You asked whether the console list even keeps a backgrounded job attached. It does, permanently. I also went after a real foreground signal rather than a heuristic, and there is not one.

MSYS is Cygwin-derived and does emulate POSIX job control. `set -m` is on in an interactive PTY, and `/proc` confirms each job gets its own pgid:

```
/proc, ctty=/dev/cons0
  win=56396 (bash)  pgid=47867   <= shell
  win=81572 (sleep) pgid=47882   background
  win=90036 (sleep) pgid=47909   foreground
```

But `/proc/<pid>/stat` field 8 (`tpgid`, the tty's foreground group) is **always -1**, in every state I tried. Cygwin does not surface `tcgetpgrp` through `/proc`. Note also that `/proc` uses Cygwin pids, not Windows pids, so it needs `/proc/<pid>/winpid` to translate.

So `/proc` enumerates exactly what the console list enumerates and adds nothing. Both answer "which processes exist here", neither answers "which owns the terminal". No point-in-time query can resolve this.

## What does distinguish them

Time. A foreground command exits before the shell takes the terminal back; a background job does not. So the disappearance of the command last reported as foreground is the evidence, and everything that coexisted with it is a background job.

That is the whole rule. It needs no new syscall, no extra process, and no threshold.

Two guards the measurements forced:

1. **The pick is sticky while nothing new attaches.** The console list outlives process exit by a poll or two, and `newestOf` reads a CIM snapshot that does not. Without this the pick falls back to an older attachment mid-command, which rewrites `reported` and destroys the disappearance absorption depends on. This was measured, not anticipated:

   ```
   +6530ms  72964 | reported=72964 prev={72964,2904}     foreground command
   +9557ms  2904  | reported=2904  prev={72964,2904}     <- pick fell back to the job
   ```

2. **Stickiness is conditional on nothing having appeared.** My first attempt made it unconditional and got *worse* than the bug, 8/13, because the first job put in the background was then held as the answer forever.

## Measurements, live Git Bash PTY

`foregroundPgid` driven at 50ms to match `schedulePoll`, since the answer is derived from a sequence and a single reading cannot show it.

```
【A】baseline
  PASS  idle                                    -> shell
  PASS  foreground command running              -> 99304 sleep.exe
  PASS  idle after it exits                     -> shell
【B】background job          (B3 and B5 both failed before)
  PASS  just after `&`                          -> 17512 sleep.exe   (residual, see below)
  PASS  foreground command beside the job       -> 41424 sleep.exe
  PASS  it exits, job remains                   -> shell
  PASS  another foreground command              -> 9588 sleep.exe
  PASS  idle again                              -> shell
【C】two background jobs
  FAIL  idle with two jobs                      -> 24016 sleep.exe   (residual)
【D】pipeline
  PASS  running / after                         -> 79356 sleep.exe / shell
【E】interrupt
  PASS  running / after Ctrl-C                  -> 89268 sleep.exe / shell

12 PASS / 1 FAIL
```

Safety, which matters more than the latency win, because absorbing a running command would settle it early and that is a correctness bug rather than a slow one:

```
【F】feeding stdin to a running command, with a background job present
  PASS  cat waiting on stdin                    -> 72984
  PASS  still foreground after a line           -> 72984
  PASS  still foreground after another          -> 72984
  PASS  idle after Ctrl-D                       -> shell
  PASS  later foreground command resolves       -> 66004
  PASS  idle again                              -> shell

6 PASS / 0 FAIL
```

The rule is safe here by construction: the running command has not disappeared, so nothing is absorbed.

## The residual, stated plainly

The command that backgrounds a job is itself resolved to that job, because at that instant the two are genuinely indistinguishable. It settles on the silence timeout once. It clears on the next foreground command observed appearing and exiting, which is what C1 above shows: `true` is too fast to be seen by any poll, so it does not clear it.

**A session running only shell builtins never observes one**, so `echo`, `cd` and bare assignments will not clear it either. That is a narrower version of the original bug and I did not want to hide it in a comment.

I can close it with a command-boundary signal. `schedulePoll` only runs while an operation is active, so a gap between calls means the previous operation settled and the shell went idle, which makes everything attached background. I did not implement it, because it needs a duration threshold and getting it wrong absorbs a running command, which is a premature settle. That is the same bounded-problem-for-unbounded-problem trade we both rejected for option 2, so it seemed like your call rather than mine.

## Verification

- `vitest run`: 46 passing, up from 41. Five new cases drive a scripted console sequence through the injectable seam.
- `tsc -p . --noEmit` clean.
- `pty-smoke`, `encoding-smoke` unchanged and passing.
- `foreground-smoke` extended with the background-job case, so CI guards it:

```
  foreground with a background job: 98504 (shell is 98504)
ok: an idle shell still resolves to itself beside a background job
```

State is per-terminal and dropped when the console can no longer be read. Resting entries are pruned by presence on every call, so the window in which a recycled pid could inherit resting status is one poll interval.
