### PR TITLE
fix: stop terminal teardown waiting out both grace windows (#22)

### DIFF
--- a/scripts/teardown-smoke.mjs
+++ b/scripts/teardown-smoke.mjs
@@ -1,0 +1,87 @@
+/**
+ * Teardown cost guard.
+ *
+ * `stopShell` calls `kill('SIGTERM')` then `kill('SIGKILL')`, and node-pty
+ * rejects a signal argument on Windows. Both throws are swallowed, so before
+ * the kill patch neither phase did anything and both grace windows expired in
+ * full before the tree-kill fallback finished the job. Measured at ~20s for an
+ * idle terminal with no descendants, against ~1.6s once the signal argument is
+ * dropped and the snapshot TTL outlives its own fill cost.
+ *
+ * The budget below is deliberately loose. It is a guard against the multi-grace
+ * regression coming back, not a benchmark.
+ *
+ * Run after `npm run build`: node scripts/teardown-smoke.mjs
+ */
+
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import process from 'node:process'
+import { Context } from '@deepseek-ai/cordis'
+import WindowsSubprocessRuntime from '../lib/index.js'
+
+const GRACE_MS = 3000
+// Two grace windows plus the retry is what the bug cost; anything under one
+// window means the shell was actually signalled.
+const BUDGET_MS = GRACE_MS
+
+function findBash() {
+  if (process.env.SMOKE_BASH !== undefined) return process.env.SMOKE_BASH
+  if (process.platform !== 'win32') return '/bin/bash'
+  for (const root of [process.env.ProgramFiles, process.env['ProgramFiles(x86)']]) {
+    if (root === undefined) continue
+    const candidate = join(root, 'Git', 'usr', 'bin', 'bash.exe')
+    if (existsSync(candidate)) return candidate
+  }
+  throw new Error('Git Bash not found; set SMOKE_BASH')
+}
+
+const delay = ms => new Promise(resolve => setTimeout(resolve, ms))
+
+async function measure(label, setup) {
+  const ctx = new Context()
+  await ctx.plugin(WindowsSubprocessRuntime)
+  const handle = await ctx.subprocess.spawnTerminal({
+    argv: [findBash(), '--noprofile', '--norc', '-i'],
+    cwd: process.cwd(),
+    rows: 24,
+    cols: 80,
+    graceMs: GRACE_MS,
+  })
+  handle.output.on('data', () => {})
+  await delay(1500)
+  if (setup !== undefined) {
+    await handle.write(setup)
+    await delay(1500)
+  }
+  const startedAt = Date.now()
+  let failure
+  try {
+    await handle.terminate()
+  } catch (error) {
+    failure = error.message
+  }
+  const elapsed = Date.now() - startedAt
+  await ctx.fiber.dispose()
+  console.log(`  ${label}: ${elapsed}ms${failure === undefined ? '' : ` (terminate threw: ${failure})`}`)
+  return { elapsed, failure }
+}
+
+const idle = await measure('idle terminal', undefined)
+const withJob = await measure('with a background job', 'sleep 300 &\n')
+
+const problems = []
+for (const [name, result] of [['idle', idle], ['background job', withJob]]) {
+  if (result.failure !== undefined) problems.push(`${name} terminate threw: ${result.failure}`)
+  if (result.elapsed > BUDGET_MS) {
+    problems.push(`${name} teardown took ${result.elapsed}ms, over the ${BUDGET_MS}ms budget,`
+      + ' which is what an unsignalled shell waiting out a grace window looks like')
+  }
+}
+
+if (problems.length > 0) {
+  console.error(`FAIL:\n  ${problems.join('\n  ')}`)
+  process.exit(1)
+}
+console.log(`ok: teardown stays under one ${GRACE_MS}ms grace window, so the shell is really being signalled`)
+process.exit(0)

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import LocalSubprocessRuntime from '@deepseek-ai/dsh-subprocess-local'
 import { WindowsProcessInspector } from './inspector.ts'
 import { installPresets } from './preset-install.ts'
 import { collectStream } from './shell-decode.ts'
-import { wrapTerminalHandle } from './terminal-wrap.ts'
+import { patchTerminalKill, wrapTerminalHandle } from './terminal-wrap.ts'
 
 export { WindowsProcessInspector } from './inspector.ts'
 export type { ProcessIdentity, WindowsInspectorInternals } from './inspector.ts'
@@ -56,9 +56,17 @@ export default class WindowsSubprocessRuntime extends LocalSubprocessRuntime {
 
   override async spawnTerminal(spec: Parameters<LocalSubprocessRuntime['spawnTerminal']>[0]): ReturnType<LocalSubprocessRuntime['spawnTerminal']> {
     const handle = await super.spawnTerminal(spec)
+    if (process.platform !== 'win32') return handle
+    // `stopShell` calls kill with a signal name, which node-pty rejects on
+    // Windows, so without this both grace windows expire before the tree-kill
+    // fallback does the work. Losing it is slow, not broken, so a pty shape we
+    // do not recognise is worth saying out loud rather than failing the spawn.
+    if (!patchTerminalKill(handle)) {
+      this.ctx?.logger?.warn?.('dsh-win32: pty exposes no kill to patch; terminal teardown will wait out both grace windows')
+    }
     // On win32 the foreground-group signal path cannot exist; deliver
     // keyboard-equivalent signals as PTY input instead (Ctrl-C injection).
-    return process.platform === 'win32' ? wrapTerminalHandle(handle) : handle
+    return wrapTerminalHandle(handle)
   }
 
   override spawn(spec: Parameters<LocalSubprocessRuntime['spawn']>[0]): ReturnType<LocalSubprocessRuntime['spawn']> {

--- a/src/inspector.test.ts
+++ b/src/inspector.test.ts
@@ -232,6 +232,28 @@ describe('WindowsProcessInspector', () => {
     expect(log.length).toBe(2)
   })
 
+
+  it('keeps a snapshot at least as long as the fill cost, so a burst pays once', () => {
+    // A fixed TTL shorter than the enumeration it caches expires before the next
+    // caller arrives, which is how terminate paid for nine of them (#8 follow-up).
+    const log: string[][] = []
+    let clock = 0
+    const inspector = new WindowsProcessInspector({
+      exec(file, args) { log.push([file, ...args]); clock += 1300; return SNAPSHOT.join('\r\n') },
+      kill() {},
+      now: () => clock,
+      consoleProcessList: () => undefined,
+    })
+    inspector.processTree(100)
+    expect(log.length).toBe(1)
+    clock += 900
+    inspector.processTree(100)
+    expect(log.length, 'still inside the measured fill cost').toBe(1)
+    clock += 500
+    inspector.processTree(100)
+    expect(log.length, 'past it, so a fresh read').toBe(2)
+  })
+
   it('short-circuits isAlive for dead pids without any exec (#8)', () => {
     const log: string[][] = []
     const inspector = fakeInspector(SNAPSHOT, log, { deadPids: [200] })

--- a/src/inspector.ts
+++ b/src/inspector.ts
@@ -44,10 +44,22 @@ const DEFAULT_INTERNALS: WindowsInspectorInternals = {
   consoleProcessList: shellPid => queryConsoleProcessList(shellPid),
 }
 
-/** One CIM enumeration costs ~900ms on a busy box (#8); terminate polls every
- * 25ms per member. A short TTL turns N-per-tick execs into at most one, and
- * staleness only errs safe (a just-exited pid costs one extra tick). */
-const SNAPSHOT_TTL_MS = 200
+/**
+ * Floor for how long a process-table snapshot stays usable (#8). Terminate polls
+ * every 25ms per member, so a short TTL turns N execs per tick into one.
+ *
+ * A fixed 200ms was self-defeating: the enumeration it caches costs ~1300ms on a
+ * busy box, so back-to-back callers always found the entry expired and paid full
+ * price every time. `terminate()` alone issued nine, ~12s of a 20s teardown. The
+ * TTL therefore also tracks the cost of the last fill, which self-tunes to the
+ * machine rather than assuming a number.
+ *
+ * Widening this does not delay noticing a death. `isAlive` settles the dead case
+ * through `kill(pid, 0)` before it ever reads the snapshot, so staleness only
+ * affects confirming a pid that is still alive, and the identity check bounds
+ * pid reuse to one TTL.
+ */
+const SNAPSHOT_TTL_FLOOR_MS = 200
 
 // Culture-invariant snapshot: pid, ppid, creation time as FILETIME int64.
 const LIST_COMMAND = '$ErrorActionPreference="Stop"; Get-CimInstance Win32_Process -Property ProcessId,ParentProcessId,CreationDate | ForEach-Object { '
@@ -86,14 +98,15 @@ function startedAfter(a: string, b: string): boolean {
 }
 
 export class WindowsProcessInspector {
-  private cached: { at: number, rows: ProcessRow[] } | undefined
+  private cached: { at: number, rows: ProcessRow[], ttl: number } | undefined
   private readonly terminals = new Map<number, TerminalForegroundState>()
 
   constructor(private readonly internals: WindowsInspectorInternals = DEFAULT_INTERNALS) {}
 
   private snapshot(): ProcessRow[] {
     const now = this.internals.now()
-    if (this.cached !== undefined && now - this.cached.at < SNAPSHOT_TTL_MS) return this.cached.rows
+    if (this.cached !== undefined && now - this.cached.at < this.cached.ttl) return this.cached.rows
+    const startedAt = now
     let output: string
     try {
       output = this.internals.exec('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', LIST_COMMAND])
@@ -109,7 +122,10 @@ export class WindowsProcessInspector {
       if (!Number.isInteger(pid) || !Number.isInteger(ppid)) continue
       rows.push({ pid, ppid, started: parts[2] })
     }
-    this.cached = { at: now, rows }
+    // Timed after the fill, so the entry outlives the cost of producing it and a
+    // second caller in the same burst is served from memory instead of paying again.
+    const filledAt = this.internals.now()
+    this.cached = { at: filledAt, rows, ttl: Math.max(SNAPSHOT_TTL_FLOOR_MS, filledAt - startedAt) }
     return rows
   }
 

--- a/src/terminal-wrap.test.ts
+++ b/src/terminal-wrap.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { toPortableEval, wrapTerminalHandle } from './terminal-wrap.ts'
+import { patchTerminalKill, toPortableEval, wrapTerminalHandle } from './terminal-wrap.ts'
 
 function fakeHandle() {
   const writes: string[] = []
@@ -120,5 +120,32 @@ describe('toPortableEval', () => {
       `printf '%s\\n' $'S1'; eval -- $'no tail'`,
     ]
     for (const data of notWrappers) expect(toPortableEval(data)).toBe(data)
+  })
+})
+
+describe('patchTerminalKill', () => {
+  it('drops the signal argument node-pty rejects on Windows', () => {
+    const calls: unknown[][] = []
+    const handle = { terminal: { kill: (...args: unknown[]) => { calls.push(args) } } }
+    expect(patchTerminalKill(handle)).toBe(true)
+    handle.terminal.kill('SIGTERM')
+    handle.terminal.kill('SIGKILL')
+    expect(calls).toEqual([[], []])
+  })
+
+  it('is idempotent, so a second spawn does not stack wrappers', () => {
+    let depth = 0
+    const handle = { terminal: { kill: () => { depth += 1 } } }
+    patchTerminalKill(handle)
+    patchTerminalKill(handle)
+    handle.terminal.kill()
+    expect(depth).toBe(1)
+  })
+
+  it('reports false for a pty shape it does not recognise', () => {
+    expect(patchTerminalKill(undefined)).toBe(false)
+    expect(patchTerminalKill({})).toBe(false)
+    expect(patchTerminalKill({ terminal: {} })).toBe(false)
+    expect(patchTerminalKill({ terminal: { kill: 'not a function' } })).toBe(false)
   })
 })

--- a/src/terminal-wrap.ts
+++ b/src/terminal-wrap.ts
@@ -72,6 +72,44 @@ export function toPortableEval(data: string): string {
   return `${data.slice(0, at)}; eval $' ${data.slice(at + WRAPPED_EVAL.length)}`
 }
 
+/** Marks an IPty whose kill has already been made signal-tolerant. */
+const KILL_PATCHED = Symbol.for('dsh-win32.killPatched')
+
+interface KillableTerminal {
+  kill?: (signal?: string) => void
+  [KILL_PATCHED]?: boolean
+}
+
+/**
+ * Make the pty's `kill` tolerate a signal argument.
+ *
+ * node-pty throws `Signals not supported on windows.` when `kill` is given one,
+ * and `stopShell` calls it exactly that way:
+ *
+ *   try { this.terminal.kill('SIGTERM') } catch { }   // swallowed
+ *   await Promise.race([this.done, delay(this.graceMs)])
+ *   try { this.terminal.kill('SIGKILL') } catch { }   // swallowed
+ *   await Promise.race([this.done, delay(this.graceMs)])
+ *
+ * Both throws are caught as "the exit callback is authoritative", so nothing
+ * ever signals the shell and both grace windows expire in full. Measured here,
+ * that is 6s of a ~10s teardown of an idle terminal with no descendants, after
+ * which `stopShell` throws and the tree-kill fallback below does the actual
+ * work. `kill()` with no argument does terminate the shell, so dropping the
+ * argument restores the intent of both phases.
+ */
+export function patchTerminalKill(handle: unknown): boolean {
+  // `terminal` is internal to the stock handle rather than part of its public
+  // type, so this is a structural reach and reports false if the shape moves.
+  const terminal = (handle as { terminal?: KillableTerminal } | undefined)?.terminal
+  if (terminal === undefined || typeof terminal.kill !== 'function') return false
+  if (terminal[KILL_PATCHED] === true) return true
+  const original = terminal.kill.bind(terminal)
+  terminal.kill = function killIgnoringSignal(): void { original() }
+  terminal[KILL_PATCHED] = true
+  return true
+}
+
 /**
  * Wrap a live terminal handle: keyboard-equivalent signals are injected as
  * input, and a failed terminate falls back to a forced tree kill. Directly


### PR DESCRIPTION
Closes #22.

Two independent causes of the ~20s teardown, both measured, both fixed here.

## The kill argument

`patchTerminalKill` makes the pty's `kill` drop the signal name, so `stopShell`'s two phases actually signal the shell instead of throwing into a swallowed catch and waiting out both grace windows. `handle.terminal` is internal to the stock handle rather than part of its public type, so the reach is structural and reports `false` if the shape moves; `spawnTerminal` warns rather than failing the spawn, because losing this is slow and not broken.

## The snapshot TTL

The entry now lives at least as long as the fill that produced it, floored at the old 200ms. A fixed TTL below the cost of the thing it caches can never serve a burst, which is how one `terminate()` paid for nine enumerations.

Widening it does not delay noticing a death. `isAlive` settles the dead case through `kill(pid, 0)` before it reads the snapshot, so staleness only affects confirming a pid that is still alive, and the start-identity check bounds pid reuse to one TTL.

## Measurements

Windows 11 build 26200, 490 processes, PowerShell 5.1, node 24.13.1, `graceMs` 3000.

```
teardown, idle terminal            20028 ms -> 1580 ms
teardown, with a background job    20000 ms -> 1616 ms
CIM enumerations per teardown             9 -> 1
```

Separately: the TTL change alone gets to 11382ms with 2 enumerations, so the kill argument is the other ~9.8s.

## Verification

- `vitest run`: 69 passing, up from 65. Four new cases: the kill patch drops the argument, is idempotent, reports false on an unrecognised shape, and the TTL outlives its own fill.
- `tsc -p . --noEmit` clean.
- `pty-smoke`, `foreground-smoke`, `encoding-smoke`, `doctor` all unchanged and passing.
- `scripts/teardown-smoke.mjs` is new and budgets teardown at one grace window:

```
  idle terminal: 1704ms
  with a background job: 1563ms
ok: teardown stays under one 3000ms grace window, so the shell is really being signalled
```

The budget is loose on purpose. Under one window means the shell was signalled at all, which is the property that regressed; it is not a benchmark and should not become one.

Suggested CI step next to the others:

```yaml
- name: teardown cost smoke (#22)
  timeout-minutes: 5
  run: node scripts/teardown-smoke.mjs
```

## One thing this does not fix

While measuring I found that a backgrounded job survives teardown entirely. `processTree(shellPid)` returns only the shell, because MSYS fork emulation severs the parent chain, so the job is never a tracked descendant and `taskkill /T` cannot reach it either. Filing that separately, since it is a different symptom with a different fix and this PR is already two things.
