### PR TITLE
Guard teardown by differential, and say when the console probe goes quiet

### DIFF
--- a/scripts/pipeline-smoke.mjs
+++ b/scripts/pipeline-smoke.mjs
@@ -14,6 +14,7 @@ import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import process from 'node:process'
 import { Context } from '@deepseek-ai/cordis'
+import { queryConsoleProcessList } from '../lib/console-list.js'
 import WindowsSubprocessRuntime from '../lib/index.js'
 
 if (process.platform !== 'win32') {
@@ -33,7 +34,7 @@ function findBash() {
 
 const delay = ms => new Promise(resolve => setTimeout(resolve, ms))
 
-function stagePids() {
+function namedPids() {
   try {
     const out = execFileSync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command',
       'Get-CimInstance Win32_Process -Property ProcessId,Name'
@@ -45,9 +46,41 @@ function stagePids() {
   }
 }
 
+/**
+ * The pipeline's stages, and only those.
+ *
+ * A machine-wide name filter is not an identity. Any `sleep` or `cat` anywhere on
+ * the box lands in it, so a background job that starts inside the 2.5s window is
+ * counted as a stage and one that outlives the SIGTERM is reported as a survivor.
+ * Measured on a workstation with unrelated poll loops running: stage counts of 3,
+ * 4, 5 and 7 for the same three-stage pipeline, with false survivors each time,
+ * against a clean 3 and 0 on an idle box. That is the #27 shape — a fixture whose
+ * relationship to the thing under test is accidental — and it reports the failure
+ * this smoke exists to catch when nothing is wrong.
+ *
+ * The console is the terminal's identity, so intersecting with its process list
+ * scopes the filter to this terminal. Returns undefined when the console cannot
+ * be read, which the caller treats as "cannot attribute" rather than "none".
+ */
+function stagePids(shellPid) {
+  const attached = queryConsoleProcessList(shellPid)
+  if (attached === undefined) return undefined
+  const onConsole = new Set(attached.pids)
+  return new Set([...namedPids()].filter(pid => onConsole.has(pid)))
+}
+
+function requireStages(shellPid, when) {
+  const pids = stagePids(shellPid)
+  if (pids === undefined) {
+    console.error(`FAIL:\n  the console probe could not read the terminal's process list ${when},`
+      + ' so stages cannot be attributed to this pipeline')
+    process.exit(1)
+  }
+  return pids
+}
+
 const ctx = new Context()
 await ctx.plugin(WindowsSubprocessRuntime)
-const before = stagePids()
 const handle = await ctx.subprocess.spawnTerminal({
   argv: [findBash(), '--noprofile', '--norc', '-i'],
   cwd: process.cwd(),
@@ -57,15 +90,18 @@ const handle = await ctx.subprocess.spawnTerminal({
 })
 handle.output.on('data', () => {})
 await delay(1500)
+// Nothing of ours is on this console yet; anything here is the shell's own doing.
+const before = requireStages(handle.pid, 'before the pipeline started')
 
 await handle.write('sleep 90 | cat | cat\n')
 await delay(2500)
-const started = [...stagePids()].filter(pid => !before.has(pid))
+const started = [...requireStages(handle.pid, 'after the pipeline started')].filter(pid => !before.has(pid))
 console.log(`  pipeline stages running: ${started.length} (${started.join(', ')})`)
 
 await handle.signalForeground('SIGTERM')
 await delay(2500)
-const survivors = started.filter(pid => stagePids().has(pid))
+const alive = requireStages(handle.pid, 'after SIGTERM')
+const survivors = started.filter(pid => alive.has(pid))
 console.log(`  still running after SIGTERM: ${survivors.length}${survivors.length > 0 ? ` (${survivors.join(', ')})` : ''}`)
 
 try {
@@ -74,8 +110,9 @@ try {
   console.log(`  terminate: ${error.message}`)
 }
 await ctx.fiber.dispose()
-for (const pid of stagePids()) {
-  if (!started.includes(pid)) continue
+// The console is gone with the shell, so sweep the pids we recorded rather than
+// re-reading it. Already-dead pids make taskkill fail, which is the normal case.
+for (const pid of started) {
   try { execFileSync('taskkill', ['/PID', String(pid), '/T', '/F'], { stdio: 'ignore', windowsHide: true }) } catch { /* gone */ }
 }
 

--- a/scripts/teardown-smoke.mjs
+++ b/scripts/teardown-smoke.mjs
@@ -8,16 +8,24 @@
  * idle terminal with no descendants, against ~1.6s once the signal argument is
  * dropped and the snapshot TTL outlives its own fill cost.
  *
- * The budget is two grace windows, because that is the exact signature of the
- * bug: an unsignalled shell waits out both before the fallback runs, so any
- * regression lands above it and nothing correct lands near it. It is a guard,
- * not a benchmark, and it is deliberately not tightened to the current numbers.
+ * An absolute budget of two grace windows was the wrong instrument (#26). What
+ * teardown actually costs is CIM enumerations and taskkill spawns, and that does
+ * not scale with `graceMs` at all — sweeping it 500/1500/3000/6000 moved elapsed
+ * by nothing (idle ~2.8-3.4s, background job ~6.0-6.5s at every value). So the
+ * budget tracked a quantity teardown does not consume, and only sat near the real
+ * cost at the one value hardcoded here. On real hardware it went four-for-nine.
  *
- * Those numbers moved once #24 gave `descendants()` real members. Teardown now
- * kills what it finds instead of sweeping an empty list, and the graceful
- * taskkill it tries first costs ~1300ms of spawn overhead per member on this
- * box. Measured here: ~3.2s idle, ~4.7s with one background job, against ~1.6s
- * when the sweep had nothing to do and ~20s before #23.
+ * The signal is differential instead. An unsignalled shell waits out both windows,
+ * so its elapsed grows by ~2x any increase in `graceMs`; a signalled one does not
+ * move. Measured, background job, three reps: current build 6218ms at 500 and
+ * 5958ms at 3000, delta -260ms. Same build with `terminal.kill` restored to
+ * node-pty's stock behaviour, which is the bug #23 fixed: 9491ms and 14526ms,
+ * delta +5035ms against a predicted 2 * 2500 = 5000ms. Nothing lands between
+ * those, and a slow box moves both terms together, which is the whole point.
+ *
+ * The absolute ceiling stays as a separate check, set generously. It is there to
+ * catch a hang, not to grade performance, so it must not be tightened to the
+ * current numbers.
  *
  * Run after `npm run build`: node scripts/teardown-smoke.mjs
  */
@@ -28,10 +36,15 @@ import process from 'node:process'
 import { Context } from '@deepseek-ai/cordis'
 import WindowsSubprocessRuntime from '../lib/index.js'
 
-const GRACE_MS = 3000
-// Both windows expiring is the failure being guarded against, so the budget sits
-// at exactly that. Real teardown work stays well under it.
-const BUDGET_MS = GRACE_MS * 2
+// The two grace values the differential is taken across. Their gap is also the
+// threshold: an unsignalled shell gains ~2x the gap, a signalled one gains ~0.
+const SHORT_GRACE_MS = 500
+const LONG_GRACE_MS = 3000
+const GRACE_GAP_MS = LONG_GRACE_MS - SHORT_GRACE_MS
+// A hang catcher, not a performance grade. Well above the ~6.5s this costs on a
+// loaded workstation and above the ~14.5s the unsignalled build reaches, so it
+// fires for something stuck rather than something slow.
+const CEILING_MS = 30_000
 
 function findBash() {
   if (process.env.SMOKE_BASH !== undefined) return process.env.SMOKE_BASH
@@ -46,7 +59,7 @@ function findBash() {
 
 const delay = ms => new Promise(resolve => setTimeout(resolve, ms))
 
-async function measure(label, setup) {
+async function measure(label, setup, graceMs) {
   const ctx = new Context()
   await ctx.plugin(WindowsSubprocessRuntime)
   const handle = await ctx.subprocess.spawnTerminal({
@@ -54,7 +67,7 @@ async function measure(label, setup) {
     cwd: process.cwd(),
     rows: 24,
     cols: 80,
-    graceMs: GRACE_MS,
+    graceMs,
   })
   handle.output.on('data', () => {})
   await delay(1500)
@@ -75,21 +88,32 @@ async function measure(label, setup) {
   return { elapsed, failure }
 }
 
-const idle = await measure('idle terminal', undefined)
-const withJob = await measure('with a background job', 'sleep 300 &\n')
+const idle = await measure('idle terminal', undefined, LONG_GRACE_MS)
+// The differential runs on the background-job case: it has a descendant, so it
+// exercises the sweep as well as the shell kill, and it is the case measured in
+// #26. Same setup either side, only graceMs differs.
+const shortGrace = await measure(`background job, ${SHORT_GRACE_MS}ms grace`, 'sleep 300 &\n', SHORT_GRACE_MS)
+const longGrace = await measure(`background job, ${LONG_GRACE_MS}ms grace`, 'sleep 300 &\n', LONG_GRACE_MS)
 
 const problems = []
-for (const [name, result] of [['idle', idle], ['background job', withJob]]) {
+for (const [name, result] of [['idle', idle], ['short grace', shortGrace], ['long grace', longGrace]]) {
   if (result.failure !== undefined) problems.push(`${name} terminate threw: ${result.failure}`)
-  if (result.elapsed > BUDGET_MS) {
-    problems.push(`${name} teardown took ${result.elapsed}ms, over the ${BUDGET_MS}ms budget,`
-      + ' which is what an unsignalled shell waiting out both grace windows looks like')
+  if (result.elapsed > CEILING_MS) {
+    problems.push(`${name} teardown took ${result.elapsed}ms, over the ${CEILING_MS}ms ceiling,`
+      + ' which is a hang rather than a slow box')
   }
+}
+
+const delta = longGrace.elapsed - shortGrace.elapsed
+console.log(`  grace differential: ${delta}ms (threshold ${GRACE_GAP_MS}ms)`)
+if (delta > GRACE_GAP_MS) {
+  problems.push(`teardown grew ${delta}ms for a ${GRACE_GAP_MS}ms increase in graceMs, so it is waiting the`
+    + ' windows out rather than being signalled; an unsignalled shell gains about twice the increase')
 }
 
 if (problems.length > 0) {
   console.error(`FAIL:\n  ${problems.join('\n  ')}`)
   process.exit(1)
 }
-console.log(`ok: teardown stays under both ${GRACE_MS}ms grace windows, so the shell is really being signalled`)
+console.log('ok: teardown does not scale with graceMs, so the shell is really being signalled')
 process.exit(0)

--- a/src/console-list.test.ts
+++ b/src/console-list.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest'
-import { parseConsoleProcessList } from './console-list.ts'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { ConsoleProbeInternals } from './console-list.ts'
+import { parseConsoleProcessList, queryConsoleProcessList, setConsoleProbeWarn } from './console-list.ts'
 
 describe('parseConsoleProcessList', () => {
   it('reads the helper payload', () => {
@@ -20,5 +21,76 @@ describe('parseConsoleProcessList', () => {
 
   it('accepts an empty list, which is a real console state', () => {
     expect(parseConsoleProcessList('{"pids":[],"self":9}')).toEqual({ pids: [], self: 9 })
+  })
+})
+
+describe('the probe says when it has gone permanently quiet', () => {
+  const LIST = '{"pids":[1,2],"self":1}'
+  /** Wiring a sink also clears the latches, so each case starts fresh. */
+  const collect = (): string[] => {
+    const warnings: string[] = []
+    setConsoleProbeWarn(message => warnings.push(message))
+    return warnings
+  }
+  const probe = (over: Partial<ConsoleProbeInternals>): ConsoleProbeInternals => ({
+    helper: () => 'helper.cjs',
+    run: () => LIST,
+    ...over,
+  })
+  const query = (internals: ConsoleProbeInternals, times: number): void => {
+    for (let i = 0; i < times; i++) queryConsoleProcessList(1234, 5_000, internals)
+  }
+
+  afterEach(() => { setConsoleProbeWarn(undefined) })
+
+  it('warns once when the helper cannot be prepared at all, however many probes follow', () => {
+    const warnings = collect()
+    query(probe({ helper: () => undefined }), 10)
+    expect(warnings).toHaveLength(1)
+    // Names the consequence, since the symptom is #7, #11 and #24 returning at once.
+    expect(warnings[0]).toMatch(/fall back to parent links/)
+  })
+
+  it('stays quiet for an isolated failure, which is the ordinary exiting-shell race', () => {
+    const warnings = collect()
+    query(probe({ run: () => { throw new Error('AttachConsole failed') } }), 1)
+    expect(warnings).toEqual([])
+  })
+
+  it('warns once on a run of failures, and not again as the run continues', () => {
+    const warnings = collect()
+    const failing = probe({ run: () => { throw new Error('AttachConsole failed') } })
+    query(failing, 3)
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toMatch(/AttachConsole failed/)
+    query(failing, 50)
+    expect(warnings).toHaveLength(1)
+  })
+
+  it('counts a run, not a total, so occasional races never accumulate into one', () => {
+    const warnings = collect()
+    let calls = 0
+    // Fails twice, succeeds, fails twice, succeeds — never three in a row.
+    const flaky = probe({
+      run: () => {
+        if (calls++ % 3 === 2) return LIST
+        throw new Error('AttachConsole failed')
+      },
+    })
+    query(flaky, 30)
+    expect(warnings).toEqual([])
+  })
+
+  it('treats output it cannot read as a failure, since the caller gets nothing either way', () => {
+    const warnings = collect()
+    query(probe({ run: () => 'not json' }), 3)
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toMatch(/output this build cannot read/)
+  })
+
+  it('returns the list and reports nothing while the probe works', () => {
+    const warnings = collect()
+    expect(queryConsoleProcessList(1234, 5_000, probe({}))).toEqual({ pids: [1, 2], self: 1 })
+    expect(warnings).toEqual([])
   })
 })

--- a/src/console-list.ts
+++ b/src/console-list.ts
@@ -32,8 +32,55 @@ export interface ConsoleProcessList {
   self: number
 }
 
-/** Undefined until first resolved; `{ path: undefined }` records a known miss. */
-let helperState: { path: string | undefined } | undefined
+/** OS boundary for the probe, injectable so the degradation paths are testable. */
+export interface ConsoleProbeInternals {
+  /** Path to the one-shot helper, or undefined when it cannot be prepared. */
+  helper(): string | undefined
+  /** Run the helper against `shellPid`, returning its stdout. Throws on failure. */
+  run(helper: string, shellPid: number, timeoutMs: number): string
+}
+
+/**
+ * Undefined until first resolved; a `path: undefined` entry records a known
+ * miss along with why, since that miss is permanent and worth saying once.
+ */
+let helperState: { path: string | undefined, reason?: string } | undefined
+
+/**
+ * Where the two "the probe has gone permanently quiet" warnings go.
+ *
+ * Both are one-shot. A resolution miss is cached forever by design, and a probe
+ * failure recurs on every call, so a terminal polling every 50ms would turn one
+ * broken install into a flood, and a flood gets filtered, which puts us back at
+ * silence. One line per process is what makes it readable.
+ */
+let warn: ((message: string) => void) | undefined
+let reportedUnavailable = false
+let reportedFailing = false
+let consecutiveFailures = 0
+
+/**
+ * When the probe cannot answer, `processTree` falls back to the stock parent
+ * walk and `signalGroup` to `[pgid]` — which on MSYS means no descendants and
+ * no fan-out, so #7, #11 and #24 all come back at once and look like a
+ * regression here rather than a moved file in node-pty. Nothing else says so,
+ * because degrading quietly is the correct behaviour for the ordinary race of
+ * probing a shell that is on its way out.
+ *
+ * Wiring a sink resets the latches, so a second plugin instance reports again.
+ */
+export function setConsoleProbeWarn(sink: ((message: string) => void) | undefined): void {
+  warn = sink
+  reportedUnavailable = false
+  reportedFailing = false
+  consecutiveFailures = 0
+}
+
+/**
+ * A run of failures with no success between them. One failure is ordinary (the
+ * shell exited mid-probe); a run of them is an install that will never answer.
+ */
+const FAILURE_RUN_BEFORE_WARNING = 3
 
 function nodePtyUtils(): string | undefined {
   const here = createRequire(import.meta.url)
@@ -60,7 +107,7 @@ function helperScript(): string | undefined {
   if (helperState !== undefined) return helperState.path
   const utils = nodePtyUtils()
   if (utils === undefined) {
-    helperState = { path: undefined }
+    helperState = { path: undefined, reason: "node-pty's conpty_console_list helper could not be located" }
     return undefined
   }
   try {
@@ -75,10 +122,14 @@ function helperScript(): string | undefined {
     ].join('\n'))
     helperState = { path }
     return path
-  } catch {
-    helperState = { path: undefined }
+  } catch (error) {
+    helperState = { path: undefined, reason: `the console-list helper could not be written (${errorText(error)})` }
     return undefined
   }
+}
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
 }
 
 /** Parse the helper's stdout. Exported for tests; tolerates any malformed shape. */
@@ -101,17 +152,49 @@ export function parseConsoleProcessList(raw: string): ConsoleProcessList | undef
  * A shell that has exited makes AttachConsole fail, which is an ordinary race
  * rather than an error, so the caller degrades instead of throwing.
  */
-export function queryConsoleProcessList(shellPid: number, timeoutMs = 5_000): ConsoleProcessList | undefined {
-  const helper = helperScript()
-  if (helper === undefined) return undefined
-  try {
-    return parseConsoleProcessList(execFileSync(process.execPath, [helper, String(shellPid)], {
-      encoding: 'utf8',
-      windowsHide: true,
-      timeout: timeoutMs,
-      stdio: ['ignore', 'pipe', 'pipe'],
-    }))
-  } catch {
+export function queryConsoleProcessList(
+  shellPid: number,
+  timeoutMs = 5_000,
+  internals: ConsoleProbeInternals = DEFAULT_PROBE_INTERNALS,
+): ConsoleProcessList | undefined {
+  const helper = internals.helper()
+  if (helper === undefined) {
+    if (!reportedUnavailable) {
+      reportedUnavailable = true
+      warn?.(`dsh-win32: ${helperState?.reason ?? 'the console probe is unavailable'};`
+        + ' terminal descendants and signal fan-out fall back to parent links, which MSYS severs')
+    }
     return undefined
   }
+  let parsed: ConsoleProcessList | undefined
+  let detail = 'the helper returned output this build cannot read'
+  try {
+    parsed = parseConsoleProcessList(internals.run(helper, shellPid, timeoutMs))
+  } catch (error) {
+    detail = errorText(error)
+  }
+  if (parsed !== undefined) {
+    consecutiveFailures = 0
+    return parsed
+  }
+  // One failure is the ordinary race of probing a shell that is already gone,
+  // which this function is documented to swallow. A run of them with no success
+  // between is an install that will never answer, and that is worth one line.
+  consecutiveFailures += 1
+  if (consecutiveFailures >= FAILURE_RUN_BEFORE_WARNING && !reportedFailing) {
+    reportedFailing = true
+    warn?.(`dsh-win32: the console probe has failed ${consecutiveFailures} times in a row (${detail});`
+      + ' terminal descendants and signal fan-out fall back to parent links, which MSYS severs')
+  }
+  return undefined
+}
+
+const DEFAULT_PROBE_INTERNALS: ConsoleProbeInternals = {
+  helper: helperScript,
+  run: (helper, shellPid, timeoutMs) => execFileSync(process.execPath, [helper, String(shellPid)], {
+    encoding: 'utf8',
+    windowsHide: true,
+    timeout: timeoutMs,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }),
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@
 import { spawnSync } from 'node:child_process'
 import type { Context } from '@deepseek-ai/cordis'
 import LocalSubprocessRuntime from '@deepseek-ai/dsh-subprocess-local'
+import { setConsoleProbeWarn } from './console-list.ts'
 import { WindowsProcessInspector } from './inspector.ts'
 import { installPresets } from './preset-install.ts'
 import { collectStream } from './shell-decode.ts'
@@ -18,8 +19,8 @@ import { patchTerminalKill, wrapTerminalHandle } from './terminal-wrap.ts'
 
 export { WindowsProcessInspector } from './inspector.ts'
 export type { ProcessIdentity, WindowsInspectorInternals } from './inspector.ts'
-export { parseConsoleProcessList, queryConsoleProcessList } from './console-list.ts'
-export type { ConsoleProcessList } from './console-list.ts'
+export { parseConsoleProcessList, queryConsoleProcessList, setConsoleProbeWarn } from './console-list.ts'
+export type { ConsoleProcessList, ConsoleProbeInternals } from './console-list.ts'
 export { wrapTerminalHandle } from './terminal-wrap.ts'
 export { findGitBash, installPreset, installPresets, busyboxPath, dshHome } from './preset-install.ts'
 export type { InstallOutcome, PresetId } from './preset-install.ts'
@@ -30,6 +31,12 @@ export default class WindowsSubprocessRuntime extends LocalSubprocessRuntime {
   constructor(ctx: Context) {
     super(ctx)
     if (process.platform === 'win32') {
+      // The console probe degrades quietly on purpose, because probing a shell
+      // that is already exiting is an ordinary race. A probe that can never
+      // answer is not, and it silently reverts descendants and signal fan-out
+      // to parent links — which MSYS severs — so it has to be sayable. One line
+      // per process; see setConsoleProbeWarn for why it is not per probe.
+      setConsoleProbeWarn(message => { ctx.logger?.warn?.(message) })
       // Field is the runtime's designed injection seam; production otherwise
       // resolves an inspector lazily per PTY spawn and throws on win32.
       this.terminalInspector = new WindowsProcessInspector() as typeof this.terminalInspector


### PR DESCRIPTION
Closes #26. Both things you said yes to, plus one I found while verifying the first and could not leave.

## 1. The teardown guard is differential now

`BUDGET_MS = GRACE_MS * 2` encoded the signature of the #23 bug, but not a quantity teardown consumes — the sweep in #26 moved `graceMs` twelvefold with no effect on elapsed. So it graded machine speed and went four-for-nine here.

Now it measures the property directly: same teardown at 500 ms and 3000 ms grace, and it fails if elapsed grew by more than the increase.

```
  idle terminal: 2330ms
  background job, 500ms grace: 5653ms
  background job, 3000ms grace: 5714ms
  grace differential: 61ms (threshold 2500ms)
ok: teardown does not scale with graceMs, so the shell is really being signalled
```

Five runs on this box: differentials of 310, 78, −7, 94, −185 ms. Five for five, where the old guard was five for nine across the same kind of sampling.

**Negative control**, because a guard that cannot fail is not a guard. With `patchTerminalKill` neutered in the built output — node-pty's stock `kill`, the exact state #23 fixed:

```
  idle terminal: 10752ms
  background job, 500ms grace: 9172ms (terminate threw: terminal cleanup failed; surviving pid: 109372)
  background job, 3000ms grace: 14697ms
  grace differential: 5525ms (threshold 2500ms)
FAIL:
  short grace terminate threw: terminal cleanup failed; surviving pid: 109372
  teardown grew 5525ms for a 2500ms increase in graceMs, so it is waiting the windows out rather than being signalled
```

Note the ceiling did **not** fire — 14.7 s is under the 30 s hang catch. The differential is what caught it, which is the division of labour you asked for. The ceiling is deliberately generous and must not be tightened to current numbers; it exists for a hang, not for a slow box.

## 2. The console probe says when it has gone quiet

Two latches, both one-shot, both through `ctx.logger.warn`:

- **Resolution miss** — node-pty unlocatable or the helper unwritable. Permanent by construction, so it warns on the first probe and never again.
- **A run of three failures with no success between them.** This is the case the first latch does not cover: the helper resolves fine but every probe fails, which is just as permanent and just as silent.

An isolated failure stays quiet, because probing a shell that is already exiting is the ordinary case this function is documented to swallow. Counting a *run* rather than a total means occasional races never accumulate into a warning — there is a test for exactly that, with a probe that fails twice and succeeds on every third call, thirty times, silent throughout.

Both messages name the consequence rather than the mechanism, since the symptom a user would see is #7, #11 and #24 returning at once and looking like a regression here:

```
dsh-win32: node-pty's conpty_console_list helper could not be located; terminal
descendants and signal fan-out fall back to parent links, which MSYS severs
```

The probe's OS boundary is injectable now (`ConsoleProbeInternals`), which is how the six new tests reach these paths without touching a real console.

## 3. pipeline-smoke was identifying stages by name, machine-wide

This one is not in your list. I found it verifying the above and it is my own smoke from #25, so I fixed it rather than filing it.

`stagePids()` matched every `sleep.exe` and `cat.exe` **on the box**. Any background job that starts inside the 2.5 s window counts as a stage, and any that outlives the SIGTERM is reported as a survivor. On this workstation, which has unrelated poll loops running, the same three-stage pipeline reported:

```
run 1 exit=1 | stages running: 7 ... still running after SIGTERM: 4
run 2 exit=1 | stages running: 5 ... still running after SIGTERM: 2
run 3 exit=1 | stages running: 5 ... still running after SIGTERM: 2
run 4 exit=1 | stages running: 4 ... still running after SIGTERM: 1
```

Four for four red, on unmodified `master`, with nothing wrong. I confirmed the residue was foreign by dumping it: `sleep 60`, `sleep 900` — commands this smoke never issues.

That is the #27 shape exactly, one week later and in my own code: a fixture whose relationship to the thing under test is accidental. The console is the terminal's identity, so intersecting the name filter with the console process list scopes it:

```
run 1..5 exit=0 | pipeline stages running: 3 | still running after SIGTERM: 0
```

Five for five, same noisy box. A console that cannot be read now fails the smoke with "cannot attribute" rather than silently reporting zero stages.

Say the word and I will split this into its own PR if you would rather keep this one to the two items you asked for.

## The double enumeration — you asked for the measurement

> the question that would move me is whether the harness blocks on teardown

**It does, on one path.** `TerminalSessionService.kill()` awaits `session.close(reason)` → `closeOnce()` → `await this.terminal.terminate()`, and that method's default reason is `"model request"`. So a model-initiated close of a PTY session blocks for the whole teardown — measured here at ~2.4 s idle and ~6 s with one background job.

`closeRecords`, used for owner cleanup and service stop, awaits too.

The one path that does **not** block is `onTransportFailure`, which does `this.terminal.terminate().catch(() => {})` — fire and forget.

So it is not free. Whether ~6 s on an explicit "close this terminal" justifies giving the inspector a concept of a teardown span is still your call, and I have not touched it here.

## Verification

- `tsc -p . --noEmit` clean
- 92 tests, 8 files, all passing — including `fs-confined` on your `7c3dfc5`
- All five smokes green
- Negative control run for the new guard, shown above

Branch is on `7c3dfc5`.
