### PR TITLE
Release dsh-win32 0.15.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Run DSH Minimal mode on Windows with the sandboxed preset.
 npx dsh-win32 setup --sandboxed
 ```
 
+DeepSeek Harness already runs natively on Windows with PowerShell. dsh-win32 adds persistent Minimal presets, including one that survives Workspace Write.
+
 This preset uses busybox ash, so Git Bash and WSL are not required.
 
 [中文](./README.zh.md) · [Windows details](./docs/windows-details.md)
@@ -40,6 +42,14 @@ After setup, start DSH, add a workspace, and choose the preset.
 
 - **Minimal (Windows, sandboxed)** uses busybox ash inside `Workspace Write`. Install it with `npx dsh-win32 setup --sandboxed`.
 - **Minimal (Windows)** uses Git Bash and needs `danger-full-access`. Install it with `npx dsh-win32 setup` after installing [Git for Windows](https://git-scm.com).
+
+Using DSH Desktop instead of the Web profile?
+
+```powershell
+npx dsh-win32 setup --sandboxed --profile desktop --no-shortcut
+```
+
+Restart DSH Desktop after setup, then choose **Minimal (Windows, sandboxed)**.
 
 ## Doctor
 

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -305,10 +305,10 @@ function runDshPlugin(args) {
   })
 }
 
-function ensureBundle() {
-  const wired = bundleVersion()
+function ensureBundle(profile = 'web') {
+  const wired = bundleVersion(profile)
   if (wired === SELF_VERSION) {
-    ok(`bundle dsh-win32@${wired} already wired into the web profile`)
+    ok(`bundle dsh-win32@${wired} already wired into the ${profile} profile`)
     return
   }
   if (wired !== undefined) {
@@ -323,7 +323,7 @@ function ensureBundle() {
       ok('pnpm enabled through corepack')
     }
   }
-  if (wired === undefined) console.log('wiring the dsh-win32 bundle into the web profile (one-time)...')
+  if (wired === undefined) console.log(`wiring the dsh-win32 bundle into the ${profile} profile (one-time)...`)
   // The profile carries a pnpm minimum-release-age gate, and its exclude list
   // only ever names the version current at wiring time, so a release published
   // today is invisible to an upgrade and pnpm answers "Already up to date"
@@ -333,7 +333,7 @@ function ensureBundle() {
   info(`installing the exact version you invoked (${SELF_VERSION}) and overriding pnpm's minimum-release-age for this install only`)
   info('the profile\'s own policy file is left untouched')
   // -w: the profile dir is a pnpm workspace root; pnpm 10+ refuses a bare add there.
-  runDshPlugin(['--profile', 'web', 'add', '-w', `dsh-win32@${SELF_VERSION}`, '--config.minimumReleaseAge=0'])
+  runDshPlugin(['--profile', profile, 'add', '-w', `dsh-win32@${SELF_VERSION}`, '--config.minimumReleaseAge=0'])
 }
 
 function fix() {
@@ -400,6 +400,12 @@ function createShortcut() {
 async function setup(args) {
   const bashFlagIndex = args.indexOf('--bash')
   const explicitBash = bashFlagIndex !== -1 ? args[bashFlagIndex + 1] : undefined
+  const profileFlagIndex = args.indexOf('--profile')
+  const profile = profileFlagIndex === -1 ? 'web' : args[profileFlagIndex + 1]
+  if (profile === undefined || !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(profile)) {
+    console.error('setup: --profile needs one safe profile name')
+    process.exit(1)
+  }
   const { gitBash } = doctor()
   console.log('')
 
@@ -411,10 +417,10 @@ async function setup(args) {
   }
   if (!args.includes('--no-bundle')) {
     try {
-      ensureBundle()
+      ensureBundle(profile)
     } catch {
       warn('bundle wiring failed. The preset still installs below; wire the bundle manually with')
-      info('npx --yes @deepseek-ai/dsh plugin --profile web add -w dsh-win32')
+      info(`npx --yes @deepseek-ai/dsh plugin --profile ${profile} add -w dsh-win32`)
     }
   }
   if (bashPath === undefined) {
@@ -442,7 +448,7 @@ async function setup(args) {
   // common `npx dsh-win32 setup` did not, which is two entry points with
   // different outcomes for no reason. --shortcut is still accepted so the
   // installer and anyone's notes keep working.
-  if (WIN && !args.includes('--no-shortcut')) {
+  if (profile === 'web' && WIN && !args.includes('--no-shortcut')) {
     try {
       createShortcut()
       console.log('created desktop shortcut "DeepSeek Harness" (skip it with --no-shortcut)')
@@ -461,11 +467,13 @@ async function setup(args) {
   // happen and the first one has no in-product guidance at all, so a user who
   // gets this far still lands on a greyed-out composer with no hint (#14).
   console.log('next, in order:')
-  if (WIN && !args.includes('--no-shortcut')) {
+  if (profile === 'web' && WIN && !args.includes('--no-shortcut')) {
     console.log('  1. double-click "DeepSeek Harness" on your desktop  (or: npx @deepseek-ai/dsh web)')
     console.log('     it opens a console, then use the EXACT url that console prints')
   } else {
-    console.log('  1. npx @deepseek-ai/dsh web        (use the EXACT url it prints)')
+    console.log(profile === 'web'
+      ? '  1. npx @deepseek-ai/dsh web        (use the EXACT url it prints)'
+      : `  1. start or restart the DSH host that uses profile "${profile}"`)
   }
   console.log('  2. sidebar > Workspaces > folder icon, and add a workspace')
   console.log('     until you do, the composer is greyed out and takes no input')
@@ -490,7 +498,7 @@ async function main([command, ...rest]) {
       remediation: rest.includes('--remediation'),
     }).exitCode
   } else {
-    console.error(`unknown command ${JSON.stringify(command)}. Usage is dsh-win32 [doctor [--json [--remediation]]|setup|fix] [--bash <path>] [--no-shortcut] [--no-bundle] [--sandboxed [--busybox <path>]]`)
+    console.error(`unknown command ${JSON.stringify(command)}. Usage is dsh-win32 [doctor [--json [--remediation]]|setup|fix] [--profile <name>] [--bash <path>] [--no-shortcut] [--no-bundle] [--sandboxed [--busybox <path>]]`)
     process.exit(1)
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-win32",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-win32",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "^0.7.3"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-win32",
-  "version": "0.15.0",
-  "description": "在 Windows 上把 DSH 用起来。一行装好极简模式的持久 shell，沙箱内也能用 | Get DSH working on Windows: persistent shell for Minimal mode, sandbox included",
+  "version": "0.15.1",
+  "description": "Native Windows shell and Workspace Write sandbox presets for DeepSeek Harness. No WSL. One command.",
   "type": "module",
   "license": "MIT",
   "repository": "github:sjh9714/dsh-win32",
@@ -14,6 +14,10 @@
     "deepseek",
     "windows",
     "win32",
+    "native-windows",
+    "no-wsl",
+    "workspace-write",
+    "sandbox",
     "git-bash",
     "persistent-shell",
     "minimal-mode"

--- a/src/setup.test.ts
+++ b/src/setup.test.ts
@@ -75,6 +75,7 @@ describe('setup on Windows', () => {
     const npx = join(bin, 'npx')
     writeFileSync(npx, '#!/bin/sh\nprintf "%s\\n" "$@" > "$DSH_NPX_ARGS"\n')
     chmodSync(npx, 0o755)
+    writeFileSync(join(bin, 'npx.cmd'), '@echo off\r\n:args\r\nif "%~1"=="" goto done\r\n>>"%DSH_NPX_ARGS%" echo %~1\r\nshift\r\ngoto args\r\n:done\r\n')
 
     const run = spawnSync(process.execPath, [CLI, 'setup', '--no-shortcut', '--profile', 'desktop', '--sandboxed', '--busybox', busybox, '--bash', bash], {
       encoding: 'utf8',

--- a/src/setup.test.ts
+++ b/src/setup.test.ts
@@ -89,7 +89,8 @@ describe('setup on Windows', () => {
     })
 
     expect(run.status).toBe(0)
-    expect(readFileSync(npxArgs, 'utf8')).toContain('--profile\ndesktop\n')
+    const argv = readFileSync(npxArgs, 'utf8').trim().split(/\r?\n/)
+    expect(argv.slice(argv.indexOf('--profile'), argv.indexOf('--profile') + 2)).toEqual(['--profile', 'desktop'])
   }, SPAWN_TIMEOUT)
 
   it('rejects an unsafe profile name before writing presets', () => {

--- a/src/setup.test.ts
+++ b/src/setup.test.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from 'node:child_process'
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { delimiter, dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import process from 'node:process'
 import { describe, expect, it } from 'vitest'
@@ -83,7 +83,7 @@ describe('setup on Windows', () => {
         ...process.env,
         DSH_HOME: home,
         DSH_NPX_ARGS: npxArgs,
-        PATH: `${bin}:${process.env.PATH ?? ''}`,
+        PATH: `${bin}${delimiter}${process.env.PATH ?? ''}`,
       },
       timeout: SPAWN_TIMEOUT,
     })

--- a/src/setup.test.ts
+++ b/src/setup.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process'
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -8,6 +8,7 @@ import { describe, expect, it } from 'vitest'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const SIM = join(here, '..', 'scripts', 'win32-sim.mjs')
+const CLI = join(here, '..', 'bin', 'cli.mjs')
 const SPAWN_TIMEOUT = 30_000
 
 function runSetup({ sandboxed, bash }: { sandboxed: boolean, bash?: string }) {
@@ -58,5 +59,54 @@ describe('setup on Windows', () => {
     expect(run.status).toBe(0)
     expect(existsSync(join(home, '.agent-presets', 'minimal-windows'))).toBe(true)
     expect(existsSync(join(home, '.agent-presets', 'minimal-windows-sandboxed'))).toBe(true)
+  }, SPAWN_TIMEOUT)
+
+  it('wires the bundle into the selected desktop profile', () => {
+    const fixtures = mkdtempSync(join(tmpdir(), 'dsh-win32-setup-profile-'))
+    const home = mkdtempSync(join(tmpdir(), 'dsh-win32-setup-profile-home-'))
+    const bash = join(fixtures, 'Git', 'usr', 'bin', 'bash.exe')
+    const busybox = join(fixtures, 'busybox64.exe')
+    const npxArgs = join(fixtures, 'npx-args.txt')
+    const bin = join(fixtures, 'bin')
+    mkdirSync(dirname(bash), { recursive: true })
+    writeFileSync(bash, '')
+    writeFileSync(busybox, '')
+    mkdirSync(bin)
+    const npx = join(bin, 'npx')
+    writeFileSync(npx, '#!/bin/sh\nprintf "%s\\n" "$@" > "$DSH_NPX_ARGS"\n')
+    chmodSync(npx, 0o755)
+
+    const run = spawnSync(process.execPath, [CLI, 'setup', '--no-shortcut', '--profile', 'desktop', '--sandboxed', '--busybox', busybox, '--bash', bash], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        DSH_HOME: home,
+        DSH_NPX_ARGS: npxArgs,
+        PATH: `${bin}:${process.env.PATH ?? ''}`,
+      },
+      timeout: SPAWN_TIMEOUT,
+    })
+
+    expect(run.status).toBe(0)
+    expect(readFileSync(npxArgs, 'utf8')).toContain('--profile\ndesktop\n')
+  }, SPAWN_TIMEOUT)
+
+  it('rejects an unsafe profile name before writing presets', () => {
+    const fixtures = mkdtempSync(join(tmpdir(), 'dsh-win32-setup-profile-unsafe-'))
+    const home = mkdtempSync(join(tmpdir(), 'dsh-win32-setup-profile-unsafe-home-'))
+    const bash = join(fixtures, 'bash.exe')
+    const busybox = join(fixtures, 'busybox64.exe')
+    writeFileSync(bash, '')
+    writeFileSync(busybox, '')
+
+    const run = spawnSync(process.execPath, [CLI, 'setup', '--no-bundle', '--no-shortcut', '--profile', 'desktop&calc', '--sandboxed', '--busybox', busybox, '--bash', bash], {
+      encoding: 'utf8',
+      env: { ...process.env, DSH_HOME: home },
+      timeout: SPAWN_TIMEOUT,
+    })
+
+    expect(run.status).toBe(1)
+    expect(run.stderr).toContain('--profile needs one safe profile name')
+    expect(existsSync(join(home, '.agent-presets'))).toBe(false)
   }, SPAWN_TIMEOUT)
 })


### PR DESCRIPTION
Adds setup support for the DSH Desktop profile and refreshes npm discovery metadata.

Verification

- 103 tests passed
- build passed
- typecheck passed
- packed tarball installed in an empty directory
- npx doctor returned the dsh-doctor v1 envelope