### PR TITLE
Verify koffi loads after installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Restart DSH Desktop after setup, then choose **Minimal (Windows, sandboxed)**.
 npx dsh-win32 doctor
 ```
 
-`doctor` lists known Windows setup traps and their safe fixes. Use `npx dsh-win32 fix` for fixes it can apply safely.
+`doctor` lists known Windows setup traps and their safe fixes. Its koffi check verifies both the installed version and a real runtime load, so a skipped install script cannot produce a false pass. Use `npx dsh-win32 fix` for fixes it can apply safely.
 
 ## Honest limits
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -143,7 +143,7 @@ npx dsh-win32 setup --no-shortcut  # 不建桌面快捷方式
 
 沙箱变体（`minimal-windows-sandboxed`）只能由 `setup --sandboxed` 安装，因为它要下载 busybox-w32，而 busybox 是 GPLv2，插件激活时静默下载既是许可问题也是同意问题。接入 bundle 还需要 pnpm，因为 `dsh plugin add` 是用它装进 profile 目录的。缺失时 `setup` 会通过 corepack 自动启用，`doctor` 也会单独列出该项。
 
-已经出问题了？`npx dsh-win32 doctor` 逐项指出已知的坑（koffi 3.1.3/3.1.4 损坏预编译导致的安装失败与选择器崩溃、缺 PowerShell 7 时 5.1 的 0xC0000142（有桌面打包版的崩溃报告，本 CLI 路径上实测受限令牌下 5.1 能正常启动）、localhost 与 127.0.0.1 的 403、System32 里的 WSL 假 bash），`npx dsh-win32 fix` 自动修复能安全修的部分。
+已经出问题了？`npx dsh-win32 doctor` 逐项指出已知的坑（koffi 3.1.3/3.1.4 损坏预编译、安装脚本跳过后实际运行时仍无法加载、缺 PowerShell 7 时 5.1 的 0xC0000142（有桌面打包版的崩溃报告，本 CLI 路径上实测受限令牌下 5.1 能正常启动）、localhost 与 127.0.0.1 的 403、System32 里的 WSL 假 bash），`npx dsh-win32 fix` 自动修复能安全修的部分，并在修复后实际加载 koffi 验证结果。
 
 `doctor` 还能吐机器可读的结果，给 CI 和支持流程用。
 

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -81,7 +81,9 @@ function scanKoffi() {
     const manifest = join(profilesDir, profile, 'node_modules', 'koffi', 'package.json')
     if (!existsSync(manifest)) continue
     try {
-      results.push({ profile, version: JSON.parse(readFileSync(manifest, 'utf8')).version })
+      const version = JSON.parse(readFileSync(manifest, 'utf8')).version
+      const loadable = tryExec(process.execPath, ['-e', 'require(process.argv[1])', dirname(manifest)]) !== undefined
+      results.push({ profile, version, loadable })
     } catch {
       // Unreadable manifest: nothing to report for this profile.
     }
@@ -179,9 +181,18 @@ function collectChecks() {
 
   const koffi = scanKoffi()
   const brokenKoffi = koffi.filter(({ version }) => version === '3.1.3' || version === '3.1.4')
-  if (brokenKoffi.length > 0) {
-    const where = brokenKoffi.map(({ profile, version }) => `${version} in "${profile}"`).join(', ')
-    add('koffi', 'warn', `broken win32-x64 prebuilt (${where}); install failures, folder-picker and session-save crashes`, 'npx dsh-win32 fix')
+  const unloadableKoffi = koffi.filter(({ loadable }) => !loadable)
+  if (brokenKoffi.length > 0 || unloadableKoffi.length > 0) {
+    const problems = []
+    if (brokenKoffi.length > 0) {
+      const where = brokenKoffi.map(({ profile, version }) => `${version} in "${profile}"`).join(', ')
+      problems.push(`broken win32-x64 prebuilt (${where}); install failures, folder-picker and session-save crashes`)
+    }
+    if (unloadableKoffi.length > 0) {
+      const where = unloadableKoffi.map(({ profile, version }) => `${version} in "${profile}"`).join(', ')
+      problems.push(`runtime load failed (${where}); skipping the install script is safe only when this load succeeds afterward`)
+    }
+    add('koffi', 'warn', problems.join('; '), 'npx dsh-win32 fix')
   } else if (koffi.length === 0) add('koffi', 'pass', 'no koffi found in any profile')
   else add('koffi', 'pass', koffi.map(({ profile, version }) => `${version} in "${profile}"`).join(', '))
 
@@ -337,16 +348,22 @@ function ensureBundle(profile = 'web') {
 }
 
 function fix() {
-  const broken = scanKoffi().filter(({ version }) => version === '3.1.3' || version === '3.1.4')
+  const broken = scanKoffi().filter(({ version, loadable }) => version === '3.1.3' || version === '3.1.4' || !loadable)
   if (broken.length === 0) {
-    ok('nothing to fix, no broken koffi prebuilt found in any profile')
+    ok('nothing to fix, every installed koffi version is supported and loads at runtime')
     return
   }
-  for (const { profile, version } of broken) {
-    console.log(`pinning koffi ${version} -> 3.1.2 in profile "${profile}"...`)
-    runDshPlugin(['--profile', profile, 'add', '-w', 'koffi@3.1.2', '--ignore-scripts'])
+  for (const { profile, version, loadable } of broken) {
+    console.log(`${loadable ? 'pinning' : 'repairing'} koffi ${version} -> 3.1.2 in profile "${profile}"...`)
+    runDshPlugin(['--profile', profile, 'add', '-w', 'koffi@3.1.2', '--ignore-scripts', '--force'])
   }
-  ok('koffi pinned; restart dsh web')
+  const remaining = scanKoffi().filter(({ version, loadable }) => version === '3.1.3' || version === '3.1.4' || !loadable)
+  if (remaining.length > 0) {
+    bad(`koffi still cannot load in ${remaining.map(({ profile }) => `"${profile}"`).join(', ')}`)
+    process.exitCode = 1
+  } else {
+    ok('koffi 3.1.2 installed and runtime load verified; restart dsh web')
+  }
 }
 
 /** setup rewrites on purpose: the user asked for this shell explicitly. */

--- a/docs/windows-details.md
+++ b/docs/windows-details.md
@@ -60,7 +60,7 @@ dsh-win32 closes that gap with four pieces.
 1. **A Windows-aware subprocess runtime for the supported rc.6 host.** Same stock runtime, plus the then-missing win32 ProcessInspector (process trees and identity via CIM, signalling via taskkill). DSH rc.8 now has its own upstream inspector. The plugin does not claim compatibility with that newer line while its pinned node-pty version remains broken on this path.
 2. **The `minimal-windows` agent preset.** A faithful copy of the official Minimal composition with one change, the PTY shell is your Git Bash. Same complete persona, same two tools, no compaction. v0.4 adds `minimal-windows-sandboxed`, a variant on busybox-w32 ash that STAYS inside the `workspace-write` ACL sandbox (`npx dsh-win32 setup --sandboxed`, downloads busybox on consent). Measured on windows-latest CI, the first persistent shell that survives the restricted token.
 3. **Legacy-encoding reads, everywhere they can exist.** Stock DSH refuses GBK/UTF-16 files outright (`FS_NOT_TEXT`) and garbles GBK output of native tools in the foreground shell. Both presets mount a filesystem reader (`dsh-win32/fs-confined` since v0.11, which also fences editor writes by the session permission mode) that sniffs and decodes GBK/UTF-16 on file reads, and since v0.5 the runtime decodes foreground-shell collect output the same way. Writes stay UTF-8, so editing a legacy file converts it. Deliberate and documented. PTY output stays undecodable at the plugin layer (node-pty decodes first), and shipped shells default to UTF-8 so the presets are unaffected.
-4. **A doctor.** Diagnoses the traps the community found the hard way. broken koffi 3.1.3/3.1.4 prebuilts (install failures, folder-picker and session-save crashes), missing PowerShell 7 (the 5.1 fallback is reported to crash with 0xC0000142 in the packaged desktop app, though a confined 5.1 starts fine on this CLI path), the localhost vs 127.0.0.1 origin 403, and the WSL bash.exe imposter in System32.
+4. **A doctor.** Diagnoses the traps the community found the hard way. It checks broken koffi 3.1.3/3.1.4 prebuilts and verifies that the installed package actually loads at runtime, then checks missing PowerShell 7 (the 5.1 fallback is reported to crash with 0xC0000142 in the packaged desktop app, though a confined 5.1 starts fine on this CLI path), the localhost vs 127.0.0.1 origin 403, and the WSL bash.exe imposter in System32.
 
 ## Install
 
@@ -91,7 +91,7 @@ The preset appears in the picker immediately. The Git Bash preset requires [Git 
 
 The sandboxed variant (`minimal-windows-sandboxed`) only installs through `setup --sandboxed`, because it needs busybox-w32 and busybox is GPLv2. Downloading it silently during plugin activation would be both a licence and a consent problem. Wiring the bundle also needs pnpm, because `dsh plugin add` installs into the profile directory with it. `setup` enables pnpm through corepack when it is missing, and `doctor` reports it either way.
 
-Something already broken? `npx dsh-win32 doctor` names each known trap. `npx dsh-win32 fix` repairs what it safely can (pins the broken koffi prebuilt).
+Something already broken? `npx dsh-win32 doctor` names each known trap. `npx dsh-win32 fix` repairs what it safely can. For koffi it installs 3.1.2 without the lifecycle script, forces the optional platform package to relink, and verifies a real runtime load afterward.
 
 `doctor` also emits machine-readable results for CI and support use.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-win32",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-win32",
-      "version": "0.15.1",
+      "version": "0.15.2",
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "^0.7.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-win32",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Native Windows shell and Workspace Write sandbox presets for DeepSeek Harness. No WSL. One command.",
   "type": "module",
   "license": "MIT",

--- a/src/doctor-envelope.test.ts
+++ b/src/doctor-envelope.test.ts
@@ -140,6 +140,32 @@ describe('dsh-doctor/v1 envelope', () => {
   }, SPAWN_TIMEOUT)
 })
 
+describe('koffi runtime loading', () => {
+  function homeWithKoffi(source: string) {
+    const home = mkdtempSync(join(tmpdir(), 'dsh-doctor-koffi-'))
+    const koffi = join(home, 'profiles', 'web', 'node_modules', 'koffi')
+    mkdirSync(koffi, { recursive: true })
+    writeFileSync(join(koffi, 'package.json'), JSON.stringify({ version: '3.1.2', main: 'index.js' }))
+    writeFileSync(join(koffi, 'index.js'), source)
+    return home
+  }
+
+  it('passes a supported koffi package that actually loads', () => {
+    const { envelope } = runDoctor({ DSH_HOME: homeWithKoffi('module.exports = {}') }, SIM)
+    const koffi = envelope.checks.find((c: any) => c.name === 'koffi')
+    expect(koffi.status).toBe('pass')
+    expect(koffi.detail).toContain('3.1.2 in "web"')
+  }, SPAWN_TIMEOUT)
+
+  it('warns when a supported version is present but cannot load', () => {
+    const { envelope } = runDoctor({ DSH_HOME: homeWithKoffi('throw new Error("native load failed")') }, SIM)
+    const koffi = envelope.checks.find((c: any) => c.name === 'koffi')
+    expect(koffi.status).toBe('warn')
+    expect(koffi.detail).toMatch(/runtime load failed/)
+    expect(koffi.fix).toBe('npx dsh-win32 fix')
+  }, SPAWN_TIMEOUT)
+})
+
 // The dsh-doctor v1.1 addendum pins the remediation key by BOUNDARY, not by a
 // character class. That distinction came out of this implementation: an early
 // draft matched /^\[([a-z_]+)\] /, which silently drops every vendor-prefixed


### PR DESCRIPTION
A Windows report in deepseek-harness discussion #197 showed another koffi failure path. pnpm can skip or fail the lifecycle check while leaving a package version that looks supported.

The doctor now starts a child Node process for each installed koffi package. A supported version that cannot be required is a warning instead of a false pass. The fix path force-relinks koffi 3.1.2 without lifecycle scripts and verifies the runtime load afterward.

Added passing and failing runtime fixtures.

Verification completed locally

- 105 tests
- typecheck
- build
- packed 0.15.2 tarball
- fresh install from the tarball
- real bin entry returned a dsh-doctor/v1 envelope