### PR TITLE
Release dsh-win32 0.16.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-win32",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-win32",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "^0.7.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-win32",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Fix and diagnose DeepSeek Harness on native Windows. Official PowerShell, Workspace Write, shortcuts, and legacy preset repair. No WSL.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Publish the consent-based Star prompt added in #38.

The prompt defaults to No and appears once after a successful interactive setup. An explicit Yes uses an authenticated GitHub CLI to call the official Star API. Without GitHub CLI authentication it opens the repository instead.

Verified with npm ci, all 108 tests, build, typecheck, npm pack, an empty-directory tarball install, and the packaged CLI entry point.