### PR TITLE
Require an explicit Star choice

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -524,15 +524,20 @@ async function offerSetupStar() {
   const githubCli = WIN ? 'gh.exe' : 'gh'
   const canStar = tryExec(githubCli, ['auth', 'status', '--hostname', 'github.com']) !== undefined
   const prompt = createInterface({ input: process.stdin, output: process.stdout })
-  let answer
+  let wantsStar
   try {
-    answer = await prompt.question(canStar
-      ? '  Star dsh-win32 with your GitHub account? [y/N] '
-      : '  Open GitHub to Star dsh-win32? [y/N] ')
+    while (wantsStar === undefined) {
+      const answer = await prompt.question(canStar
+        ? '  Star dsh-win32 with your GitHub account? [y/n] '
+        : '  Open GitHub to Star dsh-win32? [y/n] ')
+      if (/^y(?:es)?$/i.test(answer.trim())) wantsStar = true
+      else if (/^n(?:o)?$/i.test(answer.trim())) wantsStar = false
+      else console.log('  enter y or n')
+    }
   } finally {
     prompt.close()
   }
-  if (!/^y(?:es)?$/i.test(answer.trim())) return
+  if (!wantsStar) return
 
   if (canStar) {
     try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-win32",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-win32",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "^0.7.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-win32",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "Fix and diagnose DeepSeek Harness on native Windows. Official PowerShell, Workspace Write, shortcuts, and legacy preset repair. No WSL.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Remove the default answer from the post-setup Star prompt.

The prompt now displays `[y/n]` and keeps asking until the user enters `y`, `yes`, `n`, or `no`. Pressing Enter alone does not Star the repository and does not decline.

This also bumps the package to 0.16.2. Verified with all 108 tests, build, typecheck, a PTY blank-input check, npm pack, an empty-directory tarball install, and the packaged CLI entry point.