### PR TITLE
Harden current DSH compatibility operations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '03:10'
+      timezone: Asia/Seoul
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-and-patch:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '03:20'
+      timezone: Asia/Seoul
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-and-patch:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,19 @@ on:
   push:
     branches: [master, main]
   pull_request:
+  workflow_dispatch:
+  # Re-run the installed-stack acceptance against the registry's current
+  # @deepseek-ai/dsh even when this repository has not changed. The scheduled
+  # event uses only Node 22.19, but keeps both npm and strict pnpm layouts.
+  schedule:
+    - cron: '23 17 * * 0'
+
+permissions:
+  contents: read
 
 jobs:
   test:
+    if: github.event_name != 'schedule'
     strategy:
       fail-fast: false
       matrix:
@@ -99,9 +109,10 @@ jobs:
     runs-on: windows-latest
     strategy:
       fail-fast: false
-      matrix:
-        node: ['22.19.0', '24']
-        installer: [npm, pnpm-strict]
+      # Pushes, PRs, and manual runs retain the complete compatibility matrix.
+      # The weekly upstream watch halves runner use by exercising the minimum
+      # supported Node line only; both dependency layouts remain load-bearing.
+      matrix: ${{ fromJSON(github.event_name == 'schedule' && '{"node":["22.19.0"],"installer":["npm","pnpm-strict"]}' || '{"node":["22.19.0","24"],"installer":["npm","pnpm-strict"]}') }}
     name: official live acceptance (${{ matrix.installer }}, Node ${{ matrix.node }})
     steps:
       - uses: actions/checkout@v4
@@ -168,11 +179,12 @@ jobs:
           node bin/cli.mjs verify
 
   sandbox-experiment:
+    if: github.event_name != 'schedule'
     # First-ever exercise of the win32 sandboxed persistent-shell path
     # (core CI excludes terminal-bash and sandbox-local on win32).
-    # Experimental until proven: does not gate the main matrix.
+    # Known failing signatures are accepted inside the regression-watch step;
+    # a new signature is a real failure and now reaches the shared CI gate.
     runs-on: windows-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -212,6 +224,7 @@ jobs:
           fi
 
   busybox-sandboxed:
+    if: github.event_name != 'schedule'
     # v0.4 flagship proof: busybox-w32 ash survives the WRITE_RESTRICTED token
     # where MSYS bash dies at cygheap init. Gate passed 2026-08-16; now required.
     runs-on: windows-latest
@@ -238,3 +251,62 @@ jobs:
         run: |
           node bin/cli.mjs setup --legacy --no-bundle --sandboxed --busybox "$PWD/busybox64.exe"
           grep -q 'busybox64.exe' "$USERPROFILE/.dsh/.agent-presets/minimal-windows-sandboxed/agent.cordis.yml"
+
+  codeql:
+    if: github.event_name != 'schedule'
+    name: CodeQL (JavaScript and TypeScript)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v4
+        with:
+          languages: javascript-typescript
+          build-mode: none
+      - uses: github/codeql-action/analyze@v4
+
+  ci-gate:
+    # One stable branch-protection context. `always()` makes cancellation and
+    # failure visible here instead of leaving this job skipped behind a failed
+    # dependency. A scheduled run intentionally omits repository-owned tests
+    # and CodeQL, but never omits the current-official compatibility gate.
+    if: always()
+    name: ci gate
+    runs-on: ubuntu-latest
+    needs:
+      - test
+      - official-live-acceptance
+      - sandbox-experiment
+      - busybox-sandboxed
+      - codeql
+    steps:
+      - name: require every applicable gate to succeed
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TEST_RESULT: ${{ needs.test.result }}
+          OFFICIAL_RESULT: ${{ needs.official-live-acceptance.result }}
+          SANDBOX_RESULT: ${{ needs.sandbox-experiment.result }}
+          BUSYBOX_RESULT: ${{ needs.busybox-sandboxed.result }}
+          CODEQL_RESULT: ${{ needs.codeql.result }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          require_success() {
+            if [ "$2" != success ]; then
+              echo "$1 finished with $2; expected success"
+              return 1
+            fi
+          }
+
+          failed=0
+          require_success official-live-acceptance "$OFFICIAL_RESULT" || failed=1
+          if [ "$EVENT_NAME" != schedule ]; then
+            require_success test "$TEST_RESULT" || failed=1
+            require_success sandbox-experiment "$SANDBOX_RESULT" || failed=1
+            require_success busybox-sandboxed "$BUSYBOX_RESULT" || failed=1
+            require_success codeql "$CODEQL_RESULT" || failed=1
+          fi
+          exit "$failed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
         os: [windows-latest, ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
       - run: npm install
@@ -115,8 +115,8 @@ jobs:
       matrix: ${{ fromJSON(github.event_name == 'schedule' && '{"node":["22.19.0"],"installer":["npm","pnpm-strict"]}' || '{"node":["22.19.0","24"],"installer":["npm","pnpm-strict"]}') }}
     name: official live acceptance (${{ matrix.installer }}, Node ${{ matrix.node }})
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
       - run: npm install
@@ -186,8 +186,8 @@ jobs:
     # a new signature is a real failure and now reaches the shared CI gate.
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
       - run: npm install
@@ -229,8 +229,8 @@ jobs:
     # where MSYS bash dies at cygheap init. Gate passed 2026-08-16; now required.
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
       - run: npm install
@@ -261,7 +261,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: github/codeql-action/init@v4
         with:
           languages: javascript-typescript

--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ No user DSH profile, config, workspace, or PowerShell profile is loaded or chang
 
 If a timeout or output limit leaves worker or descendant containment unconfirmed, verification fails and preserves the isolated snapshot instead of deleting files under a potentially live process.
 
-The boundary is deliberate: this composes the installed official components and invokes the real persistent tool, but it does not start the complete stock Minimal host/preset or make a model request. A pass must therefore be read as component-chain acceptance, not as an end-to-end stock-session claim.
+The boundary is deliberate: this composes the installed official components and invokes the real persistent tool, but it does not start the complete stock Minimal host/preset, run the plugin installer, execute hook bridges, or make a model request. A pass must therefore be read as component-chain acceptance, not as an end-to-end stock-session or hook-enforcement claim.
+
+The repository CI installs `@deepseek-ai/dsh@latest` from scratch and runs this acceptance on real Windows. Pushes, pull requests, and manual runs cover npm and strict pnpm layouts on Node 22.19 and 24. A weekly upstream watch retains both installers on Node 22.19, so a new DSH publication is checked even when dsh-win32 itself has not changed.
 
 ## Doctor and safe repair
 
@@ -83,6 +85,15 @@ npx dsh-win32 fix
 `doctor` verifies the published DSH Windows package contract and checks local Windows failures. Its JSON output follows the `dsh-doctor/v1` envelope. Use `verify` when you need live evidence from the installed stack rather than registry metadata.
 
 `fix` only repairs installed koffi versions that are known broken or fail a real runtime load. It verifies the load again after repair.
+
+## Upstream plugin and hook boundaries
+
+Two current DSH control paths sit outside repairs that dsh-win32 can safely apply:
+
+- On Windows, `dsh plugin add` can split a local package path containing spaces, and relative package paths can resolve from an unexpected working directory ([upstream #2485](https://github.com/deepseek-ai/deepseek-harness/discussions/2485)). Prefer a published package specifier. If a local package is unavoidable, stage it at a space-free absolute path and read back the installed package identity rather than trusting a successful command alone.
+- Hook logs are not proof that enforcement happened. An interpreter-backed Claude Code hook can lose its blocking exit code through PowerShell on Windows ([upstream #2485](https://github.com/deepseek-ai/deepseek-harness/discussions/2485)), while a `{"continue": false}` result can be recorded as `decision: stop` without halting the run ([upstream #1514](https://github.com/deepseek-ai/deepseek-harness/discussions/1514)). After changing hooks or upgrading DSH, run a harmless unconditional deny canary and confirm the target action is actually blocked.
+
+`doctor` cannot prove either behavior from package metadata, and `verify` deliberately avoids user profiles, hook configuration, model requests, and plugin installation. They therefore do not report these upstream paths as passing. The canary remains a user-controlled end-to-end check until DSH exposes a safe, isolated hook acceptance interface.
 
 ## Legacy DSH
 
@@ -102,6 +113,7 @@ The legacy Git Bash preset needs `danger-full-access`. The legacy busybox preset
 
 - `doctor` checks published package metadata; `verify` separately reports and loads the selected installed DSH identity.
 - `verify` does not boot the complete stock Minimal host/preset, so host wiring and UI session ownership remain outside its pass claim.
+- Neither command validates `dsh plugin add` path handling or hook enforcement; see the upstream boundaries above.
 - PowerShell 7 is recommended. dsh-win32 does not install it.
 - A legacy busybox session uses ash rather than Bash.
 - Editing a legacy encoded file writes UTF-8.

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,0 +1,7 @@
+# dsh-win32 中文说明
+
+中文 README 已移至 [`docs/README.zh.md`](./docs/README.zh.md)。
+
+此兼容页面保留旧的 `/README.zh.md` 链接；最新安装方法、限制和安全边界请查看上面的正式文档。
+
+[English README](./README.md)

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -64,6 +64,9 @@ npx dsh-win32 doctor --legacy
 ## 限制
 
 - 当前路径检查 npm 上发布的 DSH package metadata，不能证明另一个缓存中的 launcher 正在运行同一版本
+- `verify` 只验收官方 PowerShell、terminal、subprocess、Workspace Write policy 与 ACL sandbox 组件链，不会启动完整 Minimal host，也不会验证插件安装或 hook 强制执行
+- Windows 上的本地 `dsh plugin add` 路径可能因空格被拆分；本地包请暂存到不含空格的绝对路径，并回读实际安装的 package（[上游 #2485](https://github.com/deepseek-ai/deepseek-harness/discussions/2485)）
+- hook 日志不能单独证明拦截生效；Windows PowerShell 可能丢失 interpreter hook 的阻塞退出码，而 `{"continue": false}` 也可能只记录 stop 却继续运行。修改 hook 或升级 DSH 后，请用无害的必拒绝 canary 确认目标动作真的被拦住（[上游 #2485](https://github.com/deepseek-ai/deepseek-harness/discussions/2485)、[#1514](https://github.com/deepseek-ai/deepseek-harness/discussions/1514)）
 - 推荐 PowerShell 7，但 dsh-win32 不会自动安装
 - 旧版 busybox 会话使用 ash，不是 Bash
 - 编辑旧编码文件后会保存为 UTF-8

--- a/docs/windows-details.md
+++ b/docs/windows-details.md
@@ -115,6 +115,15 @@ The output is the community `dsh-doctor/v1` envelope ([deepseek-harness#1719](ht
 
 The status literals are `pass`, `warn`, `fail` and `skip`. `node` is two-state on purpose, `pass` inside the declared range and `warn` outside it, which matches npm's EBADENGINE semantics and avoids a `fail` boundary that nothing declares.
 
+## Current upstream boundaries outside the doctor
+
+`doctor` can inspect package declarations and measured local runtime failures. `verify` can exercise the installed official PowerShell component chain in a disposable home and workspace. Neither can safely rewrite a user's profile, install a test plugin, or issue a model-driven tool call merely to claim that these separate upstream paths work.
+
+- [`dsh plugin add` path handling on Windows](https://github.com/deepseek-ai/deepseek-harness/discussions/2485) can split local paths containing spaces; relative paths can also bind to the caller's working directory. Use a published package specifier where possible. For a local package, stage it at a space-free absolute path and read the installed manifest back.
+- [Hook bridge enforcement on Windows](https://github.com/deepseek-ai/deepseek-harness/discussions/2485) can lose an interpreter's blocking exit code through PowerShell. Separately, [`continue:false` can be logged as stop without halting execution](https://github.com/deepseek-ai/deepseek-harness/discussions/1514). A harmless unconditional deny canary after hook edits and DSH upgrades is the only end-to-end proof while those reports remain unresolved.
+
+A green dsh-win32 `verify` report intentionally makes no claim about either path. Its machine-readable `boundary` names the plugin installer and hook bridges as excluded.
+
 ## Writing your own preset on Windows
 
 If your preset mounts `@deepseek-ai/dsh-terminal-bash` without an explicit `shellPath`, the default `/bin/bash` resolves to `C:\Windows\System32\bash.exe` on Windows, the WSL launcher, and the PTY exits at startup. Point it at the real shell instead.

--- a/screenshots.json
+++ b/screenshots.json
@@ -1,0 +1,5 @@
+[
+  "assets/market-card.png",
+  "assets/shot-persistent-sandboxed.png",
+  "assets/shot-preset-picker.png"
+]

--- a/src/verify.test.ts
+++ b/src/verify.test.ts
@@ -109,6 +109,8 @@ describe('verify runtime eligibility', () => {
     const report = await verifyInstalledStack({}, fakeDependencies({ platform: 'darwin', findInstalledDsh: discover }))
     expect(report.status).toBe('unsupported')
     expect(report.reason).toBe('native Windows only')
+    expect(report.boundary).toContain('plugin installer')
+    expect(report.boundary).toContain('hook bridges')
     expect(discover).not.toHaveBeenCalled()
   })
 

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -71,7 +71,7 @@ export interface VerifyDependencies {
   cleanup: (root: string) => void
 }
 
-const BOUNDARY = 'the installed model-facing persistent PowerShell tool over the official terminal, subprocess, policy, and local sandbox components; the stock Minimal host/preset is not started'
+const BOUNDARY = 'the installed model-facing persistent PowerShell tool over the official terminal, subprocess, policy, and local sandbox components; the stock Minimal host/preset, plugin installer, and hook bridges are not exercised'
 const OFFICIAL_DECLARATIONS = [
   '@deepseek-ai/dsh-tool-pwsh-persistent',
   '@deepseek-ai/dsh-pwsh-local',


### PR DESCRIPTION
## Summary

- run a weekly latest-DSH acceptance on real Windows while retaining the full PR/push matrix
- add a stable CI gate, CodeQL v4, Dependabot, and self-owned screenshot metadata
- restore the legacy Chinese README path and document the unresolved plugin/hook enforcement boundaries

## Verification

- `npm ci`
- `npm run typecheck`
- `npm run build`
- `npm test` (121/121)
- `npm pack --dry-run`
- actionlint 1.7.12
- CI-gate result simulation and screenshot asset checks