### PR TITLE
Release dsh-win32 0.17.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-win32",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-win32",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "^0.7.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-win32",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Fix and diagnose DeepSeek Harness on native Windows. Official PowerShell, Workspace Write, shortcuts, and legacy preset repair. No WSL.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- publish the current DSH compatibility hardening as 0.17.1
- keep runtime behavior unchanged from the verified master commit

## Verification
- `npm ci`
- `npm run typecheck`
- `npm run build`
- `npm test` (121 tests)
- `npm pack --dry-run --json`

The full Windows/macOS/Linux and official DSH acceptance matrix will run on this PR.