### PR TITLE
ci: materialize the Electron probe binary

### DIFF
--- a/.github/workflows/pwsh-sandbox-probe.yml
+++ b/.github/workflows/pwsh-sandbox-probe.yml
@@ -50,6 +50,12 @@ jobs:
       - name: install electron
         if: startsWith(matrix.chain, 'electron')
         run: npm install --no-save electron@43.4.0
+      # Electron 43 downloads its platform binary lazily from require(). The
+      # probe executes a fixed literal path, so materialize and verify it here
+      # without passing the resolved path through the workflow environment.
+      - name: materialize electron binary
+        if: startsWith(matrix.chain, 'electron')
+        run: node -e "const fs = require('node:fs'); const electron = require('electron'); fs.accessSync(electron); console.log(electron)"
       - name: vendor an unrelated official node
         if: matrix.chain == 'electron-spawn-vendored-node'
         shell: bash


### PR DESCRIPTION
## Summary
- trigger Electron 43.4.0's lazy platform-binary download before the manual probe
- verify the resolved binary exists without exporting its absolute path
- keep the literal-path command dispatch that closed the CodeQL finding

## Evidence
The latest `master` manual run passed both Node cells but failed both Electron cells because the package was installed while `dist/electron.exe` had not yet been materialized. Electron 43.4.0's package entrypoint downloads the binary on first `require("electron")`.

## Verification
- workflow YAML parse
- `git diff --check`
- required: full PR CI, zero open CodeQL alerts, then a fresh 4-cell Windows manual run after merge