### PR TITLE
fix: diagnose nested verify sandbox stalls

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ No user DSH profile, config, workspace, or PowerShell profile is loaded or chang
 
 If a timeout or output limit leaves worker or descendant containment unconfirmed, verification fails and preserves the isolated snapshot instead of deleting files under a potentially live process.
 
+`verify` creates its own Workspace Write policy and Windows ACL-confined PowerShell child. If you run it from an agent that is already inside another Workspace Write or Windows ACL sandbox, approve one unsandboxed/full-access execution for **this verify command only**; otherwise the nested restricted-token/ConPTY layers can stall before PowerShell launches. This does not bypass the acceptance boundary: the inner child under test remains confined, and the outside-write denial is still required to pass. Worker timeouts report only a fixed, path-free progress checkpoint so nested-launch stalls can be distinguished without exposing terminal output or environment values.
+
 The boundary is deliberate: this composes the installed official components and invokes the real persistent tool, but it does not start the complete stock Minimal host/preset, run the plugin installer, execute hook bridges, or make a model request. A pass must therefore be read as component-chain acceptance, not as an end-to-end stock-session or hook-enforcement claim.
 
 The repository CI installs `@deepseek-ai/dsh@latest` from scratch and runs this acceptance on real Windows. Pushes, pull requests, and manual runs cover npm and strict pnpm layouts on Node 22.19 and 24. A weekly upstream watch retains both installers on Node 22.19, so a new DSH publication is checked even when dsh-win32 itself has not changed.

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -65,6 +65,7 @@ npx dsh-win32 doctor --legacy
 
 - 当前路径检查 npm 上发布的 DSH package metadata，不能证明另一个缓存中的 launcher 正在运行同一版本
 - `verify` 只验收官方 PowerShell、terminal、subprocess、Workspace Write policy 与 ACL sandbox 组件链，不会启动完整 Minimal host，也不会验证插件安装或 hook 强制执行
+- `verify` 会自行创建 Workspace Write policy 和受 Windows ACL 约束的 PowerShell 子进程。如果调用它的 agent 已经位于另一层 Workspace Write 或 Windows ACL 沙箱内，请只为这一条 verify 命令批准一次非沙箱/full-access 执行；嵌套的受限 token/ConPTY 可能在 PowerShell 启动前停住。内层验收边界不会被绕过，工作区外写入仍必须被拒绝。
 - Windows 上的本地 `dsh plugin add` 路径可能因空格被拆分；本地包请暂存到不含空格的绝对路径，并回读实际安装的 package（[上游 #2485](https://github.com/deepseek-ai/deepseek-harness/discussions/2485)）
 - hook 日志不能单独证明拦截生效；Windows PowerShell 可能丢失 interpreter hook 的阻塞退出码，而 `{"continue": false}` 也可能只记录 stop 却继续运行。修改 hook 或升级 DSH 后，请用无害的必拒绝 canary 确认目标动作真的被拦住（[上游 #2485](https://github.com/deepseek-ai/deepseek-harness/discussions/2485)、[#1514](https://github.com/deepseek-ai/deepseek-harness/discussions/1514)）
 - 推荐 PowerShell 7，但 dsh-win32 不会自动安装

--- a/src/verify.test.ts
+++ b/src/verify.test.ts
@@ -215,6 +215,7 @@ describe('verify isolation orchestration with fakes', () => {
       expect(env.HOMEDRIVE).not.toBe('Z:')
       expect(env.HOMEPATH).not.toBe('\\real-user')
       expect(env.TEMP).toBe(input.runtimeTemp)
+      expect(env.DSH_WIN32_VERIFY_PROGRESS_FILE).toBe(join(input.runtimeTemp, 'worker-progress.json'))
     } finally {
       rmSync(root, { recursive: true, force: true })
     }
@@ -234,6 +235,9 @@ describe('verify isolation orchestration with fakes', () => {
 
   it('settles after a bounded post-kill grace and preserves an uncontained snapshot', async () => {
     const root = mkdtempSync(join(tmpdir(), 'dsh-win32-unclosed-worker-'))
+    const runtimeTemp = join(root, 'runtime-temp')
+    mkdirSync(runtimeTemp, { recursive: true })
+    writeFileSync(join(runtimeTemp, 'worker-progress.json'), JSON.stringify({ stage: 'powershell_launch_starting' }))
     const stdout = new PassThrough()
     const child = Object.assign(new EventEmitter(), {
       stdout,
@@ -251,7 +255,7 @@ describe('verify isolation orchestration with fakes', () => {
           workspace: join(root, 'workspace'),
           stateDirectory: join(root, 'workspace', 'state'),
           outsideFile: join(root, 'outside.txt'),
-          runtimeTemp: join(root, 'runtime-temp'),
+          runtimeTemp,
         }),
         runWorker: input => runWorker(input, {
           spawnWorker: (() => child) as unknown as typeof spawn,
@@ -271,6 +275,8 @@ describe('verify isolation orchestration with fakes', () => {
       expect(cleanup).not.toHaveBeenCalled()
       expect(report.status).toBe('fail')
       expect(report.checks.some(check => check.name === 'worker_timeout')).toBe(true)
+      expect(report.checks.find(check => check.name === 'worker_timeout')?.detail).toContain('powershell_launch_starting')
+      expect(report.checks.find(check => check.name === 'worker_timeout')?.detail).toContain('outside that outer sandbox')
       expect(report.checks.at(-1)).toEqual({
         name: 'temporary_snapshot_preserved',
         status: 'fail',
@@ -286,6 +292,9 @@ describe('verify isolation orchestration with fakes', () => {
 
   it('preserves the snapshot when the worker emits an error after timeout signaling', async () => {
     const root = mkdtempSync(join(tmpdir(), 'dsh-win32-errored-worker-'))
+    const runtimeTemp = join(root, 'runtime-temp')
+    mkdirSync(runtimeTemp, { recursive: true })
+    writeFileSync(join(runtimeTemp, 'worker-progress.json'), JSON.stringify({ stage: 'secret C:\\Users\\private' }))
     const child = Object.assign(new EventEmitter(), {
       stdout: new PassThrough(),
       exitCode: null,
@@ -305,7 +314,7 @@ describe('verify isolation orchestration with fakes', () => {
           workspace: join(root, 'workspace'),
           stateDirectory: join(root, 'workspace', 'state'),
           outsideFile: join(root, 'outside.txt'),
-          runtimeTemp: join(root, 'runtime-temp'),
+          runtimeTemp,
         }),
         runWorker: input => runWorker(input, {
           spawnWorker: (() => child) as unknown as typeof spawn,
@@ -320,6 +329,8 @@ describe('verify isolation orchestration with fakes', () => {
         'worker_timeout',
         'temporary_snapshot_preserved',
       ])
+      expect(JSON.stringify(report)).not.toContain('private')
+      expect(JSON.stringify(report)).not.toContain('secret')
     } finally {
       rmSync(root, { recursive: true, force: true })
     }

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -72,6 +72,26 @@ export interface VerifyDependencies {
 }
 
 const BOUNDARY = 'the installed model-facing persistent PowerShell tool over the official terminal, subprocess, policy, and local sandbox components; the stock Minimal host/preset, plugin installer, and hook bridges are not exercised'
+const VERIFY_PROGRESS_FILE = 'worker-progress.json'
+const VERIFY_PROGRESS_STAGES = [
+  'worker_started',
+  'installed_tree_validated',
+  'outside_control_passed',
+  'official_components_starting',
+  'official_components_composed',
+  'powershell_launch_starting',
+  'powershell_launched',
+  'persistent_state_passed',
+  'workspace_write_passed',
+  'outside_write_blocked',
+  'denial_recovery_passed',
+  'cancellation_recovery_passed',
+  'repeat_lifecycle_passed',
+  'runtime_teardown_starting',
+  'worker_finished',
+] as const
+type VerifyProgressStage = typeof VERIFY_PROGRESS_STAGES[number]
+const VERIFY_PROGRESS_STAGE_SET = new Set<string>(VERIFY_PROGRESS_STAGES)
 const OFFICIAL_DECLARATIONS = [
   '@deepseek-ai/dsh-tool-pwsh-persistent',
   '@deepseek-ai/dsh-pwsh-local',
@@ -417,6 +437,18 @@ export function isolatedEnvironment(input: WorkerInput, source: NodeJS.ProcessEn
     DSH_WIN32_VERIFY_WORKSPACE: input.workspace,
     DSH_WIN32_VERIFY_STATE_DIRECTORY: input.stateDirectory,
     DSH_WIN32_VERIFY_OUTSIDE_FILE: input.outsideFile,
+    DSH_WIN32_VERIFY_PROGRESS_FILE: join(input.runtimeTemp, VERIFY_PROGRESS_FILE),
+  }
+}
+
+function readWorkerProgress(runtimeTemp: string): VerifyProgressStage | undefined {
+  try {
+    const value = JSON.parse(readFileSync(join(runtimeTemp, VERIFY_PROGRESS_FILE), 'utf8')) as { stage?: unknown }
+    return typeof value.stage === 'string' && VERIFY_PROGRESS_STAGE_SET.has(value.stage)
+      ? value.stage as VerifyProgressStage
+      : undefined
+  } catch {
+    return undefined
   }
 }
 
@@ -491,9 +523,14 @@ export function runWorker(input: WorkerInput, options: RunWorkerOptions = {}): P
       const signal = directChildSignaled
         ? 'only its retained direct-child handle was signaled'
         : 'its retained direct-child handle could not be signaled safely'
+      const lastCheckpoint = readWorkerProgress(input.runtimeTemp)
+      const progress = lastCheckpoint === undefined ? '' : `; last safe worker checkpoint: ${lastCheckpoint}`
+      const nestedSandboxHint = terminationReason === 'timeout'
+        ? '; if verify was launched inside another Workspace Write or Windows ACL sandbox, rerun only this verify command outside that outer sandbox because verify creates and tests its own confined child'
+        : ''
       return new WorkerTerminationError(
         check,
-        `${reason}; ${signal}; temporary-root and descendant containment are unconfirmed`,
+        `${reason}${progress}; ${signal}; temporary-root and descendant containment are unconfirmed${nestedSandboxHint}`,
       )
     }
     const detachUnclosedChild = (): void => {
@@ -804,6 +841,15 @@ export async function runVerifyWorker(): Promise<VerifyReport> {
   const workspace = requireEnvironment('DSH_WIN32_VERIFY_WORKSPACE')
   const stateDirectory = requireEnvironment('DSH_WIN32_VERIFY_STATE_DIRECTORY')
   const outsideFile = requireEnvironment('DSH_WIN32_VERIFY_OUTSIDE_FILE')
+  const progressFile = requireEnvironment('DSH_WIN32_VERIFY_PROGRESS_FILE')
+  const checkpoint = (stage: VerifyProgressStage): void => {
+    try {
+      writeFileSync(progressFile, JSON.stringify({ stage }), 'utf8')
+    } catch {
+      // Progress is diagnostic-only and must never weaken or block acceptance.
+    }
+  }
+  checkpoint('worker_started')
   const checks: VerifyCheck[] = []
   const pass = (name: string, detail: string): void => { checks.push({ name, status: 'pass', detail }) }
   let harness: TerminalHarness | undefined
@@ -824,14 +870,18 @@ export async function runVerifyWorker(): Promise<VerifyReport> {
       throw new CheckFailure('installed_dsh', `installed @deepseek-ai/dsh ${manifest.version} does not declare the complete official Windows stack`)
     }
     pass('installed_dsh', `using installed @deepseek-ai/dsh ${manifest.version}, not registry metadata`)
+    checkpoint('installed_tree_validated')
 
     writeFileSync(outsideFile, 'control', 'utf8')
     if (readFileSync(outsideFile, 'utf8') !== 'control') throw new Error('outside control mismatch')
     unlinkSync(outsideFile)
     pass('outside_control', 'the isolated outside target is writable by the normal parent token')
+    checkpoint('outside_control_passed')
 
+    checkpoint('official_components_starting')
     harness = await composeOfficialHarness(tree)
     pass('official_components', 'loaded and composed the official components through that installed DSH dependency tree')
+    checkpoint('official_components_composed')
     const { ctx, agent } = harness
     if (ctx.get('systemPrompt') === undefined || ctx.get('tools') === undefined) {
       throw new CheckFailure('service_preflight', 'the stock systemPrompt/tools service pair is not active')
@@ -846,6 +896,7 @@ export async function runVerifyWorker(): Promise<VerifyReport> {
       }
     }
 
+    checkpoint('powershell_launch_starting')
     await checked('powershell_launch', 'PowerShell launched through the confined official persistent-tool chain', async () => {
       await expectToolMarker(
         ctx,
@@ -856,6 +907,7 @@ export async function runVerifyWorker(): Promise<VerifyReport> {
       if (ctx.terminals.list(agent).length !== 1) throw new Error('persistent session absent')
     })
     pass('powershell_7', 'the same child is 64-bit PowerShell 7+, has PSHOME, and reports an existing executable path')
+    checkpoint('powershell_launched')
 
     const firstSession = String(ctx.terminals.list(agent)[0]?.sessionId ?? '')
     await checked('persistent_state', 'two model-facing pwsh calls retained cwd and environment in one PTY', async () => {
@@ -870,6 +922,7 @@ export async function runVerifyWorker(): Promise<VerifyReport> {
       if (firstSession === '' || current !== firstSession) throw new Error('tool changed PTY')
       if (readFileSync(join(stateDirectory, 'state-location.txt'), 'utf8') !== 'cwd-ok') throw new Error('cwd state mismatch')
     })
+    checkpoint('persistent_state_passed')
 
     await checked('workspace_write_read', 'exact content was written and read inside the temporary workspace', async () => {
       await expectToolMarker(
@@ -880,6 +933,7 @@ export async function runVerifyWorker(): Promise<VerifyReport> {
       )
       if (readFileSync(join(stateDirectory, 'inside.txt'), 'utf8') !== 'inside-ok') throw new Error('inside content mismatch')
     })
+    checkpoint('workspace_write_passed')
 
     await checked('outside_write_blocked', 'the control-writable target was denied under Workspace Write and no file was created', async () => {
       await expectToolMarker(
@@ -890,11 +944,13 @@ export async function runVerifyWorker(): Promise<VerifyReport> {
       )
       if (existsSync(outsideFile)) throw new Error('outside file exists')
     })
+    checkpoint('outside_write_blocked')
 
     await checked('denial_recovery', 'the same persistent-tool PTY remained usable after the denied write', async () => {
       await expectToolMarker(ctx, agent, "[Console]::WriteLine(('DSH_VERIFY_DENIAL_' + 'RECOVERY_OK'))", 'DSH_VERIFY_DENIAL_RECOVERY_OK')
       if (String(ctx.terminals.list(agent)[0]?.sessionId ?? '') !== firstSession) throw new Error('tool changed PTY')
     })
+    checkpoint('denial_recovery_passed')
 
     await checked('cancel_recovery', 'cancellation tore down the first PTY and the next pwsh call spawned a working replacement', async () => {
       await cancelTool(ctx, agent)
@@ -902,11 +958,13 @@ export async function runVerifyWorker(): Promise<VerifyReport> {
       const replacement = String(ctx.terminals.list(agent)[0]?.sessionId ?? '')
       if (replacement === '' || replacement === firstSession) throw new Error('replacement PTY absent')
     })
+    checkpoint('cancellation_recovery_passed')
 
     await checked('repeat_lifecycle', 'two persistent PTYs completed spawn, cancellation, and awaited teardown', async () => {
       await cancelTool(ctx, agent)
       if (ctx.terminals.list(agent).length !== 0) throw new Error('second PTY remains')
     })
+    checkpoint('repeat_lifecycle_passed')
   } catch (error) {
     const failure = error instanceof CheckFailure
       ? error
@@ -914,6 +972,7 @@ export async function runVerifyWorker(): Promise<VerifyReport> {
     checks.push({ name: failure.check, status: 'fail', detail: failure.safeDetail })
   } finally {
     if (harness !== undefined) {
+      checkpoint('runtime_teardown_starting')
       try {
         harness.disposeAgent()
         await withTimeout(harness.ctx.fiber.dispose(), 20_000)
@@ -930,6 +989,7 @@ export async function runVerifyWorker(): Promise<VerifyReport> {
     })
   }
   const ok = checks.length > 0 && checks.every(check => check.status === 'pass')
+  checkpoint('worker_finished')
   return {
     schema: 'dsh-win32/verify/v1',
     status: ok ? 'pass' : 'fail',


### PR DESCRIPTION
## Summary
- record fixed, path-free worker progress checkpoints inside the isolated verify runtime
- include the last allowlisted checkpoint in timeout reports
- explain the one-command outer-sandbox exception while keeping the inner DSH Workspace Write and ACL acceptance boundary intact
- add regression coverage for checkpoint reporting and rejection of untrusted checkpoint text

## Reproduction
On native Windows, wrapping dsh-win32 verify in an outer Codex Workspace Write/elevated sandbox caused worker_timeout and snapshot preservation before the inner PowerShell launch. The exact published dsh-win32 0.17.3 command passed all 14 checks and temporary cleanup when invoked without the extra outer sandbox. This isolates the failure to nested restricted-token/ConPTY layers rather than the inner DSH boundary.

## Validation
- npm test: 12 files, 166 tests passed
- npm run typecheck
- npm run build
- npm pack --dry-run
- node bin/cli.mjs verify --json: 14 checks passed on Windows 11 with Node 24.19.0 and PowerShell 7.6.4

No user paths, terminal output, or environment values are written to the report.