### PR TITLE
patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-win32",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-win32",
-      "version": "0.17.3",
+      "version": "0.17.4",
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "^0.7.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-win32",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "description": "Fix and diagnose DeepSeek Harness on native Windows. Official PowerShell, Workspace Write, shortcuts, and legacy preset repair. No WSL.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Prepare dsh-win32 0.17.4 after #56. This change only updates the package and lockfile versions; the verifier changes were reviewed in #56. Local validation passed: npm ci, all 166 tests, typecheck, build, and npm pack --dry-run.