### PR TITLE
patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ It does not install Git, PowerShell, busybox, WSL, or another DSH bundle on the 
 
 [中文](./docs/README.zh.md) · [Windows evidence and legacy details](./docs/windows-details.md)
 
+Using a coding agent? [Copy the setup and verification request](https://github.com/sjh9714/dsh-win32/blob/master/docs/agent-setup.md). For a guided walkthrough, see [Windows troubleshooting in Chinese](https://github.com/sjh9714/dsh-win32/blob/master/docs/windows-first-run.zh.md).
+
 <p>
 <a href="https://www.npmjs.com/package/dsh-win32"><img src="https://img.shields.io/npm/v/dsh-win32?style=flat-square&label=npm&color=cb3837" alt="npm"></a>
 <a href="https://github.com/sjh9714/dsh-win32/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/sjh9714/dsh-win32/ci.yml?style=flat-square&label=CI" alt="CI"></a>
@@ -98,6 +100,18 @@ Two current DSH control paths sit outside repairs that dsh-win32 can safely appl
 - Hook logs are not proof that enforcement happened. An interpreter-backed Claude Code hook can lose its blocking exit code through PowerShell on Windows ([upstream #2485](https://github.com/deepseek-ai/deepseek-harness/discussions/2485)), while a `{"continue": false}` result can be recorded as `decision: stop` without halting the run ([upstream #1514](https://github.com/deepseek-ai/deepseek-harness/discussions/1514)). After changing hooks or upgrading DSH, run a harmless unconditional deny canary and confirm the target action is actually blocked.
 
 `doctor` cannot prove either behavior from package metadata, and `verify` deliberately avoids user profiles, hook configuration, model requests, and plugin installation. They therefore do not report these upstream paths as passing. The canary remains a user-controlled end-to-end check until DSH exposes a safe, isolated hook acceptance interface.
+
+## Bring an existing setup
+
+Once the Windows checks pass, [dsh-movein](https://github.com/sjh9714/dsh-movein) can preview importing an existing Claude Code, Codex, or OpenCode setup. It is optional and separate from Windows setup: dsh-win32 does not install it for you.
+
+Start with a preview in the project you want to move. Do not add `--apply` until you have reviewed the destinations, conflicts, and unsupported settings.
+
+```powershell
+npx dsh-movein
+```
+
+Moving configuration does not prove hook enforcement or a complete stock Minimal session. Keep the verification boundaries above.
 
 ## Legacy DSH
 

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -14,6 +14,8 @@ npx dsh-win32 setup
 
 [English](../README.md) · [Windows 实证与旧版细节](./windows-details.md)
 
+让 coding agent 帮忙时，可以复制[安装与验收指令](https://github.com/sjh9714/dsh-win32/blob/master/docs/agent-setup.md#中文)。第一次排错请看[Windows PowerShell 故障：先诊断，再验证](https://github.com/sjh9714/dsh-win32/blob/master/docs/windows-first-run.zh.md)。
+
 <p>
 <a href="https://www.npmjs.com/package/dsh-win32"><img src="https://img.shields.io/npm/v/dsh-win32?style=flat-square&label=npm&color=cb3837" alt="npm"></a>
 <a href="https://github.com/sjh9714/dsh-win32/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/sjh9714/dsh-win32/ci.yml?style=flat-square&label=CI" alt="CI"></a>
@@ -48,6 +50,12 @@ npx dsh-win32 fix
 `doctor` 检查官方 Windows stack 和本机已知故障。JSON 输出遵循 `dsh-doctor/v1`。
 
 `fix` 只处理已知损坏或真实加载失败的 koffi 版本，修复后会再次执行加载验证。
+
+## Windows 正常后，再搬现有配置
+
+[dsh-movein](https://github.com/sjh9714/dsh-movein) 可以预演搬入 Claude Code、Codex 或 OpenCode 配置。它是可选的另一项操作；dsh-win32 不会自动安装它。
+
+在需要搬入的项目目录中先运行 `npx dsh-movein`，查看目标、冲突和不支持项，确认后才使用 `--apply`。搬入配置不代表 hook 强制生效，也不代表完整 Minimal 会话已经验收。
 
 ## 旧版 DSH
 

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -1,0 +1,65 @@
+# Set up DSH on Windows with a coding agent
+
+[English README](../README.md) · [中文](#中文)
+
+Copy the request below into your coding agent. This is a request to inspect and set up the current official Windows stack, not permission to rewrite a profile or relax security settings.
+
+```text
+Help me set up current DeepSeek Harness on native Windows with dsh-win32.
+Read https://github.com/sjh9714/dsh-win32 before running commands.
+
+1. Check the OS, Node version, PowerShell 7, installed DSH identity, and intended
+   profile. Node 22.19+ or 24+ is required; Node 23 is unsupported. On another OS,
+   stop. If prerequisites are missing, explain the official installation steps
+   and ask before installing or upgrading anything.
+2. Preserve existing profiles, presets, credentials, and package-manager policy.
+   Do not select --legacy, disable Workspace Write, or change global settings.
+3. Run npx dsh-win32 doctor --json. Explain warnings without exposing paths or
+   secrets. Metadata checks are not proof that the installed runtime works.
+4. Explain proposed changes before npx dsh-win32 setup. The default web path
+   creates a desktop shortcut; use --no-shortcut if I do not want one. A fix
+   command is separate: identify its affected installations and ask first.
+5. Run npx dsh-win32 verify --json against the installed DSH. If another sandbox
+   prevents the verifier from starting, ask for a one-command permission grant;
+   do not weaken the user's profile or bypass a denied request.
+6. Report the actual installed versions and separate passed, failed, and unrun
+   checks. verify covers the official component chain, not the complete Minimal
+   host, plugin installation, hook enforcement, or a model-driven session.
+7. If setup emits USER_CONFIRMATION_REQUIRED, ask me the repository Star question
+   and wait for my explicit answer. Never infer Yes from this setup request.
+8. Stop on an unresolved failure. Do not repeatedly reinstall, lower release-age
+   policy, publish logs, or import another setup without a separate request.
+```
+
+If `dsh` is not on `PATH`, use the [official launch instructions](https://github.com/deepseek-ai/deepseek-harness#run), which currently use `npx @deepseek-ai/dsh web`. Do not assume dsh-win32 installs DSH or PowerShell.
+
+Use a non-default profile only when the user identifies it. `setup --profile NAME --no-shortcut` and `verify --profile NAME --json` select that profile; do not invent a new one to make a failing check pass.
+
+Once Windows is working, [Movein's separate migration request](https://github.com/sjh9714/dsh-movein/blob/main/docs/agent-setup.md) can help with existing settings. Neither request authorizes installing both tools automatically.
+
+## 中文
+
+把下面这段复制给 coding agent。Windows 修复与配置搬家是两项独立操作。
+
+```text
+请用 dsh-win32 帮我检查并配置原生 Windows 上的当前版 DeepSeek Harness。
+先阅读 https://github.com/sjh9714/dsh-win32 。
+
+1. 确认 Windows、Node、PowerShell 7、已安装 DSH 的版本和目标 profile。
+   需要 Node 22.19+ 或 24+，不支持 Node 23；不是 Windows 就停止。
+   缺少前置软件时，说明官方安装办法，先询问再安装或升级。
+2. 保留现有 profile、预设、凭据和包管理器政策；不要自动选 --legacy、
+   关闭 Workspace Write 或修改全局设置。
+3. 运行 npx dsh-win32 doctor --json，解释警告，不公开路径或密钥。
+   package metadata 正常不代表本机 runtime 已经通过。
+4. 说明变更后运行 npx dsh-win32 setup；不需要桌面快捷方式就使用
+   --no-shortcut。fix 是另一项操作，先明确影响哪些安装并征得同意。
+5. 对已安装 DSH 运行 npx dsh-win32 verify --json。若外层沙箱导致无法
+   启动验收，仅申请这一条命令的权限；不要降低 profile 的安全设置。
+6. 分别报告真实版本、通过、失败和未执行项。verify 只验证官方组件链，
+   不证明完整 Minimal host、插件安装、hook 强制执行或模型会话正常。
+7. 遇到 USER_CONFIRMATION_REQUIRED 就向我询问 Star 问题，等待明确回答；
+   不要把“安装”当成同意 Star。
+8. 未解决的失败必须停止；不要反复重装、降低发布等待期、公开日志，
+   或未经另外请求就搬入其他工具的配置。
+```

--- a/docs/windows-first-run.zh.md
+++ b/docs/windows-first-run.zh.md
@@ -1,0 +1,68 @@
+# DSH 在 Windows 上 PowerShell 启动失败：先诊断，再验证
+
+[English README](../README.md) · [中文 README](./README.zh.md) · [给 coding agent 的指令](./agent-setup.md#中文)
+
+当前 DSH 已经自带持久 PowerShell 与 Windows ACL 沙箱。遇到启动失败时，不必先换成 WSL 或旧版 Git Bash 预设。下面按“缺前置软件、已知 runtime 故障、真实组件验收”分开处理。
+
+这是一份操作指南，不是本次新增的 Windows 录屏。仓库现有 GIF 是重现动画；Windows CI 的组件链验收也不等于完整 Minimal 会话验收。
+
+## 1. 先确认环境
+
+在 PowerShell 中检查：
+
+```powershell
+node --version
+pwsh -NoProfile -Command '$PSVersionTable.PSVersion.ToString()'
+npx dsh-win32 doctor --json
+```
+
+需要原生 Windows、PowerShell 7 和 Node 22.19+ 或 24+，不支持 Node 23。缺少前置软件时先按官方说明安装；dsh-win32 不负责安装 PowerShell、Git、WSL 或 DSH。
+
+`doctor` 会检查发布的 DSH Windows package contract，并定位已知本机问题。只看到官方 package metadata 正常，还不能判断某个缓存中的 launcher 真能启动。
+
+## 2. 只处理已确认的问题
+
+如果诊断指出 koffi 的已知坏版本或实际加载失败，先确认受影响的安装与变更范围，再运行：
+
+```powershell
+npx dsh-win32 fix
+npx dsh-win32 doctor --json
+```
+
+没有对应故障就跳过修复。不要为消除报错而关闭 Workspace Write、改变全局 pnpm 配置，或自动切到 `--legacy`。
+
+完成前置检查后，可创建默认 Web profile 的桌面快捷方式：
+
+```powershell
+npx dsh-win32 setup
+```
+
+不需要快捷方式时使用 `npx dsh-win32 setup --no-shortcut`。当前 setup 保留官方 profile 和预设；启动入口参见 [DSH 官方说明](https://github.com/deepseek-ai/deepseek-harness#run)。
+
+## 3. 验证真正安装的组件，而不只看命令成功
+
+```powershell
+npx dsh-win32 verify --json
+```
+
+这个命令不需要模型或 API key。它在临时环境中检查 PowerShell 的持久状态、工作区内读写、工作区外写入拒绝、中断和清理。失败或未执行的项目必须保留为失败或未执行，不能写成“全部支持”。
+
+若 agent 的外层沙箱阻止验收程序启动，只为这条 verify 命令申请一次权限；内层被测 PowerShell 仍须保持 ACL 限制。不要改变用户日常使用的安全设置。
+
+通过之后仍有明确边界：它没有启动完整 stock Minimal host，没有验证插件安装、hook 强制执行或模型工作流。使用时选择官方 **Minimal** 并保持 **Workspace Write**，不要把组件结果宣传成完整 TUI 验证。
+
+## 4. 已有 Claude Code 配置怎么办？
+
+Windows 正常之后，可以另行使用 [dsh-movein](https://github.com/sjh9714/dsh-movein)。在原项目目录先预演：
+
+```powershell
+npx dsh-movein
+```
+
+确认目标、冲突与不支持项后才添加 `--apply`。这不是 Windows 修复的必需步骤，也不会自动搬入会话历史。先看 [Movein 的安全试用例子](https://github.com/sjh9714/dsh-movein/blob/main/docs/first-migration.zh.md)。
+
+## 反馈哪类信息有用？
+
+在 [issue](https://github.com/sjh9714/dsh-win32/issues) 中说明 Node、DSH、dsh-win32 版本，以及失败的检查名称。只提供已脱敏的最小复现，不上传整个配置、终端日志、路径、凭据或工作区内容。
+
+如果实际解决了你的问题，欢迎在 [GitHub 仓库](https://github.com/sjh9714/dsh-win32) 自愿 Star。它不是安装、排错或获得帮助的条件。


### PR DESCRIPTION
## Summary

- Add English/Chinese copy-paste setup and verification requests for coding agents.
- Add a Chinese Windows troubleshooting walkthrough and an optional Movein next step.
- Keep the official component-chain boundary, existing consent flow, profiles, security policy, and package version unchanged.
- Do not claim a new Windows recording or complete stock Minimal session acceptance.

## Verification

- Fresh `npm ci`; `npm test`: 13 files / 170 tests passed.
- `npm run build` and `npm run typecheck` passed.
- Onboarding documentation across both repositories: 9 Markdown documents, 44 local/cross-repository links, balanced code fences, and rendered-page checks passed.
- No production source, dependency manifest, or lockfile changes.
