### PR TITLE
patch

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,16 +8,25 @@ labels: bug
 
 <!-- What you did, what you expected, what you got. Error text verbatim if any. -->
 
-**doctor output (required)**
+**Failed check and short redacted error**
 
 ```
-paste the full output of:  npx dsh-win32 doctor
+Run npx dsh-win32 doctor --json and name the failed or warning checks.
+Do not paste credentials, private paths, full configuration, or terminal logs.
 ```
 
 **Environment**
 
-- DSH version (`npx @deepseek-ai/dsh --version`):
+- Actual installed DSH version and launcher used:
+- Node and PowerShell versions:
 - dsh-win32 version:
-- Preset used: minimal-windows / minimal-windows-sandboxed / other
+- Preset used: stock Minimal / explicit legacy preset / other
 - Permission mode: workspace-write / danger-full-access
 - Windows version + locale (e.g. Win11 23H2, zh-CN):
+
+**Verification reached**
+
+- `verify`: passed / failed / not run
+- Stock Minimal session: worked / blocked / not run
+
+These are separate results: `verify` does not boot the complete Minimal session.

--- a/.github/ISSUE_TEMPLATE/first-run.md
+++ b/.github/ISSUE_TEMPLATE/first-run.md
@@ -1,0 +1,25 @@
+---
+name: First-run feedback / 首次试用
+about: Tell us what worked or stopped your Windows DSH setup
+title: '[First run] '
+---
+
+Share a short result, including attempts that remain blocked. Do not upload full logs, private paths, credentials, configuration, or workspace contents.
+
+### Environment / 环境
+
+- Windows, Node, PowerShell, actual installed DSH, and dsh-win32 versions:
+- Preset and permission mode:
+
+### Intended task / 想完成的任务
+
+What were you trying to do? What was the original failure, if any?
+
+### What happened / 实际结果
+
+- Doctor: passed / warning / failed / not run
+- Supported repair, if needed: worked / blocked / not needed / not run
+- Verify component checks: passed / failed / not run
+- Stock Minimal session and a small model-backed task: worked / blocked / not run
+
+Which step helped or still needs work? Component verification and a full session are separate results.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ It does not install Git, PowerShell, busybox, WSL, or another DSH bundle on the 
 
 Using a coding agent? [Copy the setup and verification request](https://github.com/sjh9714/dsh-win32/blob/master/docs/agent-setup.md). For a guided walkthrough, see [Windows troubleshooting in Chinese](https://github.com/sjh9714/dsh-win32/blob/master/docs/windows-first-run.zh.md).
 
+Start with the [Windows first-run walkthrough](./docs/windows-first-run.md) if DSH will not launch or a check fails. It follows one problem from diagnosis through the next verification step. [Share your first-run result](https://github.com/sjh9714/dsh-win32/issues/new?template=first-run.md), including attempts that are still blocked.
+
 <p>
 <a href="https://www.npmjs.com/package/dsh-win32"><img src="https://img.shields.io/npm/v/dsh-win32?style=flat-square&label=npm&color=cb3837" alt="npm"></a>
 <a href="https://github.com/sjh9714/dsh-win32/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/sjh9714/dsh-win32/ci.yml?style=flat-square&label=CI" alt="CI"></a>

--- a/docs/windows-first-run.md
+++ b/docs/windows-first-run.md
@@ -1,0 +1,52 @@
+# Get past a DSH startup problem on Windows
+
+[README](../README.md) · [中文](./windows-first-run.zh.md) · [Coding-agent request](./agent-setup.md)
+
+Use this when the official DSH Windows installation will not start PowerShell, or after a runtime update leaves you unsure what failed. dsh-win32 checks the current official stack and repairs specific known failures. It does not install DSH, PowerShell, Git, or WSL.
+
+## Find the failing step
+
+In native PowerShell, check the prerequisites and run the diagnostic:
+
+```powershell
+node --version
+pwsh -NoProfile -Command '$PSVersionTable.PSVersion.ToString()'
+npx dsh-win32 doctor --json
+```
+
+Use PowerShell 7 and DSH-supported Node 22.19+ or 24+; Node 23 is unsupported. Install missing prerequisites using their official instructions. Record the actual installed DSH identity when several launchers are present.
+
+If the diagnosis identifies a known broken koffi version or a real koffi load failure, review the affected installation before running:
+
+```powershell
+npx dsh-win32 fix
+npx dsh-win32 doctor --json
+```
+
+If no supported repair applies, retain the failed check and its short error. Repeated installation is not a diagnosis. Keep Workspace Write and package-manager policy in place.
+
+## Verify the installed stack
+
+```powershell
+npx dsh-win32 verify --json
+```
+
+This uses temporary files and the installed official components to check persistent PowerShell state, workspace read/write, outside-write denial, cancellation, and cleanup. It needs no model account. A pass establishes this component chain; the complete stock Minimal session and hook enforcement are separate checks.
+
+When a coding agent's outer sandbox blocks the verifier, request access for this one command. The verifier's own inner Workspace Write boundary stays enabled. Preserve any snapshot the command retains after an unconfirmed shutdown.
+
+## Open your first session
+
+`npx dsh-win32 setup` checks the current setup and creates the Web-profile desktop shortcut. Use `--no-shortcut` if you do not want one. Launch DSH using the shortcut or its [official instructions](https://github.com/deepseek-ai/deepseek-harness#run), add a workspace, and select stock **Minimal** with **Workspace Write**.
+
+If you already configured a model provider, ask for one small task in a disposable workspace, such as reading a sample README. Record separately whether the UI opened, the tool ran, and the expected answer appeared. A model task can incur normal provider usage. Without a provider, mark that task **not run** rather than inferring success from `verify`.
+
+Once the host works, [Movein's first-task guide](https://github.com/sjh9714/dsh-movein/blob/main/docs/first-task.md) explains how to try existing coding-agent configuration. It is optional.
+
+## Share a result or record a demonstration
+
+We are collecting first-run feedback: [versions, intended task, and the step reached](https://github.com/sjh9714/dsh-win32/issues/new?template=first-run.md). A still-blocked attempt helps as much as a success. Share only a short redacted error or synthetic reproduction, never full configuration, credentials, private paths, or workspace contents.
+
+For a real Windows recording, use an empty sample workspace and a clean terminal. Show the observed failure, the supported repair only if one is needed, then the same check succeeding. If the machine is healthy, label the clip as a healthy-stack check; do not invent a failure. Show a model-backed task only if it actually ran. Review every frame before publishing.
+
+The README's existing GIF is a reproduced animation, not that recording. A component-check clip also must not be labelled as a complete Blue/Minimal session test.


### PR DESCRIPTION
Windows first-run guidance now follows the current official PowerShell stack from a failed check through a supported repair and the next verification step. The feedback form separates component acceptance from an actual Minimal session, and the bug template no longer asks for full logs or assumes a legacy preset.

Adds an English walkthrough and a short first-run feedback template. The existing reproduced GIF keeps its label; no Windows recording or complete-session pass is claimed.

Validation: reviewed the command paths against the current CLI and README; `git diff --check` passed. Runtime code is unchanged.
